### PR TITLE
Refactor setting Facility ID on a new Compliance Work Entry

### DIFF
--- a/src/AppServices/Compliance/WorkEntries/WorkEntryService.Mapping.cs
+++ b/src/AppServices/Compliance/WorkEntries/WorkEntryService.Mapping.cs
@@ -16,20 +16,20 @@ public sealed partial class WorkEntryService
     private async Task<WorkEntry> CreateWorkEntryFromDtoAsync(IWorkEntryCreateDto resource,
         ApplicationUser? currentUser, CancellationToken token = default)
     {
+        var facilityId = (FacilityId)resource.FacilityId!;
         var workEntry = resource switch
         {
-            AccCreateDto => entryManager.Create(WorkEntryType.AnnualComplianceCertification, currentUser),
+            AccCreateDto => entryManager.Create(WorkEntryType.AnnualComplianceCertification, currentUser, facilityId),
             InspectionCreateDto dto => dto.IsRmpInspection
-                ? entryManager.Create(WorkEntryType.RmpInspection, currentUser)
-                : entryManager.Create(WorkEntryType.Inspection, currentUser),
-            NotificationCreateDto => entryManager.Create(WorkEntryType.Notification, currentUser),
-            PermitRevocationCreateDto => entryManager.Create(WorkEntryType.PermitRevocation, currentUser),
-            ReportCreateDto => entryManager.Create(WorkEntryType.Report, currentUser),
-            SourceTestReviewCreateDto => entryManager.Create(WorkEntryType.SourceTestReview, currentUser),
+                ? entryManager.Create(WorkEntryType.RmpInspection, currentUser, facilityId)
+                : entryManager.Create(WorkEntryType.Inspection, currentUser, facilityId),
+            NotificationCreateDto => entryManager.Create(WorkEntryType.Notification, currentUser, facilityId),
+            PermitRevocationCreateDto => entryManager.Create(WorkEntryType.PermitRevocation, currentUser, facilityId),
+            ReportCreateDto => entryManager.Create(WorkEntryType.Report, currentUser, facilityId),
+            SourceTestReviewCreateDto => entryManager.Create(WorkEntryType.SourceTestReview, currentUser, facilityId),
             _ => throw new ArgumentException("Invalid create DTO resource."),
         };
 
-        workEntry.Facility = await facilityService.GetAsync((FacilityId)resource.FacilityId!).ConfigureAwait(false);
         workEntry.ResponsibleStaff = resource.ResponsibleStaffId == null
             ? null
             : await userService.GetUserAsync(resource.ResponsibleStaffId).ConfigureAwait(false);

--- a/src/Domain/ComplianceEntities/WorkEntries/AnnualComplianceCertification.cs
+++ b/src/Domain/ComplianceEntities/WorkEntries/AnnualComplianceCertification.cs
@@ -7,7 +7,7 @@ public class AnnualComplianceCertification : WorkEntry
     [UsedImplicitly] // Used by ORM.
     private AnnualComplianceCertification() { }
 
-    internal AnnualComplianceCertification(int? id) : base(id)
+    internal AnnualComplianceCertification(int? id, FacilityId facilityId) : base(id, facilityId)
     {
         WorkEntryType = WorkEntryType.AnnualComplianceCertification;
     }

--- a/src/Domain/ComplianceEntities/WorkEntries/BaseInspection.cs
+++ b/src/Domain/ComplianceEntities/WorkEntries/BaseInspection.cs
@@ -11,7 +11,7 @@ public abstract class BaseInspection : ComplianceEvent
     [UsedImplicitly] // Used by ORM.
     protected BaseInspection() { }
 
-    protected BaseInspection(int? id, ApplicationUser? user) : base(id)
+    protected BaseInspection(int? id, ApplicationUser? user, FacilityId facilityId) : base(id, facilityId)
     {
         Close(user);
     }

--- a/src/Domain/ComplianceEntities/WorkEntries/ComplianceEvent.cs
+++ b/src/Domain/ComplianceEntities/WorkEntries/ComplianceEvent.cs
@@ -7,7 +7,7 @@ public abstract class ComplianceEvent : WorkEntry
     [UsedImplicitly] // Used by ORM.
     private protected ComplianceEvent() { }
 
-    private protected ComplianceEvent(int? id) : base(id)
+    private protected ComplianceEvent(int? id, FacilityId facilityId) : base(id, facilityId)
     {
         IsComplianceEvent = true;
         EpaDxStatus = DxStatus.Inserted;

--- a/src/Domain/ComplianceEntities/WorkEntries/IWorkEntryManager.cs
+++ b/src/Domain/ComplianceEntities/WorkEntries/IWorkEntryManager.cs
@@ -9,8 +9,9 @@ public interface IWorkEntryManager
     /// </summary>
     /// <param name="type">The <see cref="WorkEntryType"/> of the Work Entry to create.</param>
     /// <param name="user">The user creating the entity.</param>
+    /// <param name="facilityId">The ID of the facility associated with the Work Entry.</param>
     /// <returns>The Work Entry that was created.</returns>
-    WorkEntry Create(WorkEntryType type, ApplicationUser? user);
+    WorkEntry Create(WorkEntryType type, ApplicationUser? user, FacilityId facilityId);
 
     /// <summary>
     /// Updates the properties of a <see cref="WorkEntry"/> to indicate that it was reviewed and closed.

--- a/src/Domain/ComplianceEntities/WorkEntries/Inspection.cs
+++ b/src/Domain/ComplianceEntities/WorkEntries/Inspection.cs
@@ -9,7 +9,7 @@ public class Inspection : BaseInspection
     [UsedImplicitly] // Used by ORM.
     private Inspection() { }
 
-    internal Inspection(int? id, ApplicationUser? user) : base(id, user)
+    internal Inspection(int? id, ApplicationUser? user, FacilityId facilityId) : base(id, user, facilityId)
     {
         WorkEntryType = WorkEntryType.Inspection;
     }

--- a/src/Domain/ComplianceEntities/WorkEntries/Notification.cs
+++ b/src/Domain/ComplianceEntities/WorkEntries/Notification.cs
@@ -10,7 +10,7 @@ public class Notification : WorkEntry
     [UsedImplicitly] // Used by ORM.
     private Notification() { }
 
-    internal Notification(int? id, ApplicationUser? user) : base(id)
+    internal Notification(int? id, ApplicationUser? user, FacilityId facilityId) : base(id, facilityId)
     {
         WorkEntryType = WorkEntryType.Notification;
         Close(user);

--- a/src/Domain/ComplianceEntities/WorkEntries/PermitRevocation.cs
+++ b/src/Domain/ComplianceEntities/WorkEntries/PermitRevocation.cs
@@ -7,7 +7,7 @@ public class PermitRevocation : WorkEntry
     [UsedImplicitly] // Used by ORM.
     private PermitRevocation() { }
 
-    internal PermitRevocation(int? id) : base(id)
+    internal PermitRevocation(int? id, FacilityId facilityId) : base(id, facilityId)
     {
         WorkEntryType = WorkEntryType.PermitRevocation;
     }

--- a/src/Domain/ComplianceEntities/WorkEntries/Report.cs
+++ b/src/Domain/ComplianceEntities/WorkEntries/Report.cs
@@ -11,7 +11,7 @@ public class Report : ComplianceEvent
     [UsedImplicitly] // Used by ORM.
     private Report() { }
 
-    internal Report(int? id, ApplicationUser? user) : base(id)
+    internal Report(int? id, ApplicationUser? user, FacilityId facilityId) : base(id, facilityId)
     {
         WorkEntryType = WorkEntryType.Report;
         Close(user);

--- a/src/Domain/ComplianceEntities/WorkEntries/RmpInspection.cs
+++ b/src/Domain/ComplianceEntities/WorkEntries/RmpInspection.cs
@@ -9,7 +9,7 @@ public class RmpInspection : BaseInspection
     [UsedImplicitly] // Used by ORM.
     private RmpInspection() { }
 
-    internal RmpInspection(int? id, ApplicationUser? user) : base(id, user)
+    internal RmpInspection(int? id, ApplicationUser? user, FacilityId facilityId) : base(id, user, facilityId)
     {
         WorkEntryType = WorkEntryType.RmpInspection;
     }

--- a/src/Domain/ComplianceEntities/WorkEntries/SourceTestReview.cs
+++ b/src/Domain/ComplianceEntities/WorkEntries/SourceTestReview.cs
@@ -9,7 +9,7 @@ public class SourceTestReview : ComplianceEvent
     [UsedImplicitly] // Used by ORM.
     private SourceTestReview() { }
 
-    internal SourceTestReview(int? id, ApplicationUser? user) : base(id)
+    internal SourceTestReview(int? id, ApplicationUser? user, FacilityId facilityId) : base(id, facilityId)
     {
         WorkEntryType = WorkEntryType.SourceTestReview;
         Close(user);

--- a/src/Domain/ComplianceEntities/WorkEntries/WorkEntry.cs
+++ b/src/Domain/ComplianceEntities/WorkEntries/WorkEntry.cs
@@ -12,9 +12,10 @@ public abstract class WorkEntry : AuditableSoftDeleteEntity<int>, IComplianceEnt
     [UsedImplicitly] // Used by ORM.
     private protected WorkEntry() { }
 
-    private protected WorkEntry(int? id)
+    private protected WorkEntry(int? id, FacilityId facilityId)
     {
         if (id is not null) Id = id.Value;
+        FacilityId = facilityId;
     }
 
     // Properties: Facility

--- a/src/Domain/ComplianceEntities/WorkEntries/WorkEntryManager.cs
+++ b/src/Domain/ComplianceEntities/WorkEntries/WorkEntryManager.cs
@@ -1,22 +1,22 @@
-﻿using AirWeb.Domain.Identity;
+using AirWeb.Domain.Identity;
 
 namespace AirWeb.Domain.ComplianceEntities.WorkEntries;
 
 public class WorkEntryManager(IWorkEntryRepository repository) : IWorkEntryManager
 {
-    public WorkEntry Create(WorkEntryType type, ApplicationUser? user)
+    public WorkEntry Create(WorkEntryType type, ApplicationUser? user, FacilityId facilityId)
     {
         var id = repository.GetNextId();
 
         WorkEntry item = type switch
         {
-            WorkEntryType.AnnualComplianceCertification => new AnnualComplianceCertification(id),
-            WorkEntryType.Inspection => new Inspection(id, user),
-            WorkEntryType.Notification => new Notification(id, user),
-            WorkEntryType.PermitRevocation => new PermitRevocation(id),
-            WorkEntryType.Report => new Report(id, user),
-            WorkEntryType.RmpInspection => new RmpInspection(id, user),
-            WorkEntryType.SourceTestReview => new SourceTestReview(id, user),
+            WorkEntryType.AnnualComplianceCertification => new AnnualComplianceCertification(id, facilityId),
+            WorkEntryType.Inspection => new Inspection(id, user, facilityId),
+            WorkEntryType.Notification => new Notification(id, user, facilityId),
+            WorkEntryType.PermitRevocation => new PermitRevocation(id, facilityId),
+            WorkEntryType.Report => new Report(id, user, facilityId),
+            WorkEntryType.RmpInspection => new RmpInspection(id, user, facilityId),
+            WorkEntryType.SourceTestReview => new SourceTestReview(id, user, facilityId),
             _ => throw new ArgumentException("Invalid work entry type.", nameof(type)),
         };
 

--- a/src/TestData/Compliance/AccData.cs
+++ b/src/TestData/Compliance/AccData.cs
@@ -8,10 +8,9 @@ internal static partial class WorkEntries
 {
     internal static IEnumerable<AnnualComplianceCertification> AccData =>
     [
-        new(5001)
+        new(5001, DomainData.GetRandomFacility().Id)
         {
             WorkEntryType = WorkEntryType.AnnualComplianceCertification,
-            Facility = DomainData.GetRandomFacility(),
             ResponsibleStaff = UserData.GetUsers.ElementAt(0),
             AcknowledgmentLetterDate =
                 DateOnly.FromDateTime(DateTimeOffset.Now.AddYears(-4).AddDays(-10).Date),
@@ -32,10 +31,9 @@ internal static partial class WorkEntries
             ResubmittalRequired = false,
             EnforcementNeeded = false,
         },
-        new(5002)
+        new(5002, DomainData.GetRandomFacility().Id)
         {
             WorkEntryType = WorkEntryType.AnnualComplianceCertification,
-            Facility = DomainData.GetRandomFacility(),
             ResponsibleStaff = UserData.GetUsers.ElementAt(1),
             AcknowledgmentLetterDate =
                 DateOnly.FromDateTime(DateTimeOffset.Now.AddYears(-3).AddDays(-10).Date),
@@ -59,10 +57,9 @@ internal static partial class WorkEntries
             ResubmittalRequired = true,
             EnforcementNeeded = true,
         },
-        new(5003)
+        new(5003, DomainData.GetRandomFacility().Id)
         {
             WorkEntryType = WorkEntryType.AnnualComplianceCertification,
-            Facility = DomainData.GetRandomFacility(),
             ResponsibleStaff = UserData.GetUsers.ElementAt(3),
             AcknowledgmentLetterDate = null,
             Notes = "Deleted ACC",

--- a/src/TestData/Compliance/InspectionData.cs
+++ b/src/TestData/Compliance/InspectionData.cs
@@ -8,10 +8,9 @@ internal static partial class WorkEntries
 {
     internal static IEnumerable<Inspection> InspectionData =>
     [
-        new(6001, null)
+        new(6001, null, DomainData.GetRandomFacility().Id)
         {
             WorkEntryType = WorkEntryType.Inspection,
-            Facility = DomainData.GetRandomFacility(),
             ResponsibleStaff = UserData.GetUsers.ElementAt(0),
             AcknowledgmentLetterDate =
                 DateOnly.FromDateTime(DateTimeOffset.Now.AddYears(-4).AddDays(-10).Date),
@@ -29,10 +28,9 @@ internal static partial class WorkEntries
             DeviationsNoted = false,
             FollowupTaken = false,
         },
-        new(6002, null)
+        new(6002, null, DomainData.GetRandomFacility().Id)
         {
             WorkEntryType = WorkEntryType.Inspection,
-            Facility = DomainData.GetRandomFacility(),
             ResponsibleStaff = UserData.GetUsers.ElementAt(1),
             AcknowledgmentLetterDate =
                 DateOnly.FromDateTime(DateTimeOffset.Now.AddYears(-2).Date),
@@ -50,10 +48,9 @@ internal static partial class WorkEntries
             DeviationsNoted = true,
             FollowupTaken = true,
         },
-        new(6003, null)
+        new(6003, null, DomainData.GetRandomFacility().Id)
         {
             WorkEntryType = WorkEntryType.Inspection,
-            Facility = DomainData.GetRandomFacility(),
             ResponsibleStaff = UserData.GetUsers.ElementAt(3),
             AcknowledgmentLetterDate = null,
             Notes = "Deleted Inspection",

--- a/src/TestData/Compliance/NotificationData.cs
+++ b/src/TestData/Compliance/NotificationData.cs
@@ -8,11 +8,10 @@ internal static partial class WorkEntries
 {
     internal static IEnumerable<Notification> NotificationData =>
     [
-        new(7001, UserData.GetUsers.ElementAt(0))
+        new(7001, UserData.GetUsers.ElementAt(0), DomainData.GetRandomFacility().Id)
         {
             WorkEntryType = WorkEntryType.Notification,
             NotificationType = DomainData.GetRandomNotificationType(),
-            Facility = DomainData.GetRandomFacility(),
             ResponsibleStaff = UserData.GetUsers.ElementAt(0),
             AcknowledgmentLetterDate =
                 DateOnly.FromDateTime(DateTimeOffset.Now.AddYears(-4).AddDays(-10).Date),
@@ -25,11 +24,10 @@ internal static partial class WorkEntries
             SentDate = DateOnly.FromDateTime(DateTime.Now.AddYears(-4).AddDays(-20)),
             FollowupTaken = false,
         },
-        new(7002, UserData.GetUsers.ElementAt(1))
+        new(7002, UserData.GetUsers.ElementAt(1), DomainData.GetRandomFacility().Id)
         {
             WorkEntryType = WorkEntryType.Notification,
             NotificationType = DomainData.GetRandomNotificationType(),
-            Facility = DomainData.GetRandomFacility(),
             ResponsibleStaff = UserData.GetUsers.ElementAt(1),
             AcknowledgmentLetterDate =
                 DateOnly.FromDateTime(DateTimeOffset.Now.AddYears(-2).Date),
@@ -42,11 +40,10 @@ internal static partial class WorkEntries
             SentDate = null,
             FollowupTaken = false,
         },
-        new(7003, null)
+        new(7003, null, DomainData.GetRandomFacility().Id)
         {
             WorkEntryType = WorkEntryType.Notification,
             NotificationType = DomainData.GetRandomNotificationType(),
-            Facility = DomainData.GetRandomFacility(),
             ResponsibleStaff = UserData.GetUsers.ElementAt(3),
             AcknowledgmentLetterDate = null,
             Notes = "Deleted Inspection",

--- a/src/TestData/Compliance/PermitRevocationData.cs
+++ b/src/TestData/Compliance/PermitRevocationData.cs
@@ -1,4 +1,4 @@
-﻿using AirWeb.Domain.ComplianceEntities.WorkEntries;
+using AirWeb.Domain.ComplianceEntities.WorkEntries;
 using AirWeb.TestData.Identity;
 using AirWeb.TestData.SampleData;
 
@@ -8,10 +8,9 @@ internal static partial class WorkEntries
 {
     internal static IEnumerable<PermitRevocation> PermitRevocationData =>
     [
-        new(8001)
+        new(8001, DomainData.GetRandomFacility().Id)
         {
             WorkEntryType = WorkEntryType.PermitRevocation,
-            Facility = DomainData.GetRandomFacility(),
             ResponsibleStaff = UserData.GetUsers.ElementAt(0),
             AcknowledgmentLetterDate =
                 DateOnly.FromDateTime(DateTimeOffset.Now.AddYears(-4).AddDays(-10).Date),
@@ -23,10 +22,9 @@ internal static partial class WorkEntries
             PhysicalShutdownDate = DateOnly.FromDateTime(DateTimeOffset.Now.AddYears(-4).AddDays(-21).Date),
             FollowupTaken = false,
         },
-        new(8002)
+        new(8002, DomainData.GetRandomFacility().Id)
         {
             WorkEntryType = WorkEntryType.PermitRevocation,
-            Facility = DomainData.GetRandomFacility(),
             ResponsibleStaff = UserData.GetUsers.ElementAt(1),
             AcknowledgmentLetterDate =
                 DateOnly.FromDateTime(DateTimeOffset.Now.AddYears(-3).AddDays(-10).Date),
@@ -41,10 +39,9 @@ internal static partial class WorkEntries
             PhysicalShutdownDate = null,
             FollowupTaken = true,
         },
-        new(8003)
+        new(8003, DomainData.GetRandomFacility().Id)
         {
             WorkEntryType = WorkEntryType.PermitRevocation,
-            Facility = DomainData.GetRandomFacility(),
             ResponsibleStaff = UserData.GetUsers.ElementAt(3),
             AcknowledgmentLetterDate = null,
             Notes = "Deleted permit revocation",

--- a/src/TestData/Compliance/ReportData.cs
+++ b/src/TestData/Compliance/ReportData.cs
@@ -8,10 +8,9 @@ internal static partial class WorkEntries
 {
     internal static IEnumerable<Report> ReportData =>
     [
-        new(9001, UserData.GetUsers.ElementAt(0))
+        new(9001, UserData.GetUsers.ElementAt(0), DomainData.GetRandomFacility().Id)
         {
             WorkEntryType = WorkEntryType.Report,
-            Facility = DomainData.GetRandomFacility(),
             ResponsibleStaff = UserData.GetUsers.ElementAt(0),
             AcknowledgmentLetterDate =
                 DateOnly.FromDateTime(DateTimeOffset.Now.AddYears(-4).AddDays(-10).Date),
@@ -30,10 +29,9 @@ internal static partial class WorkEntries
             ReportsDeviations = false,
             EnforcementNeeded = false,
         },
-        new(9002, UserData.GetUsers.ElementAt(1))
+        new(9002, UserData.GetUsers.ElementAt(1), DomainData.GetRandomFacility().Id)
         {
             WorkEntryType = WorkEntryType.Report,
-            Facility = DomainData.GetRandomFacility(),
             ResponsibleStaff = UserData.GetUsers.ElementAt(1),
             AcknowledgmentLetterDate =
                 DateOnly.FromDateTime(DateTimeOffset.Now.AddYears(-2).Date),
@@ -52,10 +50,9 @@ internal static partial class WorkEntries
             ReportsDeviations = true,
             EnforcementNeeded = true,
         },
-        new(9003, null)
+        new(9003, null, DomainData.GetRandomFacility().Id)
         {
             WorkEntryType = WorkEntryType.Report,
-            Facility = DomainData.GetRandomFacility(),
             ResponsibleStaff = UserData.GetUsers.ElementAt(3),
             AcknowledgmentLetterDate = null,
             Notes = "Deleted Report",

--- a/src/TestData/Compliance/RmpInspectionData.cs
+++ b/src/TestData/Compliance/RmpInspectionData.cs
@@ -8,10 +8,9 @@ internal static partial class WorkEntries
 {
     internal static IEnumerable<RmpInspection> RmpInspectionData =>
     [
-        new(10001, UserData.GetUsers.ElementAt(0))
+        new(10001, UserData.GetUsers.ElementAt(0), DomainData.GetRandomFacility().Id)
         {
             WorkEntryType = WorkEntryType.RmpInspection,
-            Facility = DomainData.GetRandomFacility(),
             ResponsibleStaff = UserData.GetUsers.ElementAt(0),
             AcknowledgmentLetterDate =
                 DateOnly.FromDateTime(DateTimeOffset.Now.AddYears(-4).AddDays(-10).Date),
@@ -28,10 +27,9 @@ internal static partial class WorkEntries
             DeviationsNoted = false,
             FollowupTaken = false,
         },
-        new(10002, UserData.GetUsers.ElementAt(1))
+        new(10002, UserData.GetUsers.ElementAt(1), DomainData.GetRandomFacility().Id)
         {
             WorkEntryType = WorkEntryType.RmpInspection,
-            Facility = DomainData.GetRandomFacility(),
             ResponsibleStaff = UserData.GetUsers.ElementAt(1),
             AcknowledgmentLetterDate =
                 DateOnly.FromDateTime(DateTimeOffset.Now.AddYears(-2).Date),
@@ -48,10 +46,9 @@ internal static partial class WorkEntries
             DeviationsNoted = true,
             FollowupTaken = true,
         },
-        new(10003, null)
+        new(10003, null, DomainData.GetRandomFacility().Id)
         {
             WorkEntryType = WorkEntryType.RmpInspection,
-            Facility = DomainData.GetRandomFacility(),
             ResponsibleStaff = UserData.GetUsers.ElementAt(3),
             AcknowledgmentLetterDate = null,
             Notes = "Deleted RMP Inspection",

--- a/src/TestData/Compliance/SourceTestReviewData.cs
+++ b/src/TestData/Compliance/SourceTestReviewData.cs
@@ -9,11 +9,10 @@ internal static partial class WorkEntries
 {
     internal static IEnumerable<SourceTestReview> SourceTestReviewData =>
     [
-        new(11001, UserData.GetUsers.ElementAt(0))
+        new(11001, UserData.GetUsers.ElementAt(0), FacilityData.GetFacility(SourceTestData.GetData[0].Facility!.Id).Id)
         {
             WorkEntryType = WorkEntryType.SourceTestReview,
             ReferenceNumber = SourceTestData.GetData[0].ReferenceNumber,
-            Facility = FacilityData.GetFacility(SourceTestData.GetData[0].Facility!.Id),
             ResponsibleStaff = UserData.GetUsers.ElementAt(0),
             AcknowledgmentLetterDate =
                 DateOnly.FromDateTime(DateTimeOffset.Now.AddYears(-3).AddDays(-10).Date),
@@ -25,11 +24,10 @@ internal static partial class WorkEntries
             DueDate = DateOnly.FromDateTime(DateTime.Now.AddYears(-3).AddMonths(-2)),
             FollowupTaken = false,
         },
-        new(11002, UserData.GetUsers.ElementAt(1))
+        new(11002, UserData.GetUsers.ElementAt(1), FacilityData.GetFacility(SourceTestData.GetData[0].Facility!.Id).Id)
         {
             WorkEntryType = WorkEntryType.SourceTestReview,
             ReferenceNumber = SourceTestData.GetData[1].ReferenceNumber,
-            Facility = FacilityData.GetFacility(SourceTestData.GetData[0].Facility!.Id),
             ResponsibleStaff = UserData.GetUsers.ElementAt(1),
             AcknowledgmentLetterDate =
                 DateOnly.FromDateTime(DateTimeOffset.Now.AddYears(-2).Date),
@@ -41,11 +39,10 @@ internal static partial class WorkEntries
             DueDate = DateOnly.FromDateTime(DateTime.Now.AddYears(-2).AddMonths(-2)),
             FollowupTaken = true,
         },
-        new(11003, null)
+        new(11003, null, FacilityData.GetFacility(SourceTestData.GetData[0].Facility!.Id).Id)
         {
             WorkEntryType = WorkEntryType.SourceTestReview,
             ReferenceNumber = SourceTestData.GetData[2].ReferenceNumber,
-            Facility = FacilityData.GetFacility(SourceTestData.GetData[0].Facility!.Id),
             ResponsibleStaff = UserData.GetUsers.ElementAt(3),
             AcknowledgmentLetterDate = null,
             Notes = "Deleted Source Test Review",

--- a/tests/AppServicesTests/WorkEntries/Service/CreateTests.cs
+++ b/tests/AppServicesTests/WorkEntries/Service/CreateTests.cs
@@ -18,10 +18,11 @@ public class CreateTests
         // Arrange
         const int id = 901;
         var user = new ApplicationUser { Id = Guid.NewGuid().ToString(), Email = SampleText.ValidEmail };
-        var workEntry = new PermitRevocation(id);
+        var facilityId = (FacilityId)"00100001";
+        var workEntry = new PermitRevocation(id, facilityId);
 
         var workEntryManagerMock = Substitute.For<IWorkEntryManager>();
-        workEntryManagerMock.Create(Arg.Any<WorkEntryType>(), Arg.Any<ApplicationUser?>())
+        workEntryManagerMock.Create(Arg.Any<WorkEntryType>(), Arg.Any<ApplicationUser?>(), Arg.Any<FacilityId>())
             .Returns(workEntry);
 
         var userServiceMock = Substitute.For<IUserService>();
@@ -38,7 +39,6 @@ public class CreateTests
                 Arg.Any<object?[]>())
             .Returns(AppNotificationResult.SuccessResult());
 
-        var facilityId = (FacilityId)"00100001";
         var facility = new Facility(facilityId);
 
         var facilityRepository = Substitute.For<IFacilityService>();

--- a/tests/AppServicesTests/WorkEntries/Service/FindTests.cs
+++ b/tests/AppServicesTests/WorkEntries/Service/FindTests.cs
@@ -14,7 +14,7 @@ public class FindTests
     public async Task WhenItemExists_ReturnsViewDto()
     {
         // Arrange
-        var item = new PermitRevocation(902) { Facility = new Facility(SampleText.ValidFacilityId) };
+        var item = new PermitRevocation(902, new FacilityId(SampleText.ValidFacilityId));
 
         var repoMock = Substitute.For<IWorkEntryRepository>();
         repoMock.ExistsAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
@@ -25,7 +25,7 @@ public class FindTests
             .Returns(WorkEntryType.PermitRevocation);
 
         var facilityRepoMock = Substitute.For<IFacilityService>();
-        facilityRepoMock.GetAsync(item.Facility.Id)
+        facilityRepoMock.GetAsync(new FacilityId(item.FacilityId))
             .Returns(item.Facility);
 
         var appService = new WorkEntryService(AppServicesTestsSetup.Mapper!, repoMock,


### PR DESCRIPTION
Fixes #189

Refactors the `WorkEntry` and related entities to take Facility ID as a parameter in the constructor. Also updates `IWorkEntryManager` and other affected classes to pass the Facility ID parameter where needed.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gaepdit/air-web/pull/199?shareId=45b23b0a-1b1b-4ab0-915a-ed78e4e26646).