### PR TITLE
Refactor the Facility ID

### DIFF
--- a/src/AppServices/CommonSearch/CommonFilters.cs
+++ b/src/AppServices/CommonSearch/CommonFilters.cs
@@ -32,7 +32,7 @@ internal static class CommonFilters
         this Expression<Func<TEntity, bool>> predicate,
         string? input) where TEntity : IFacilityId
     {
-        var cleanInput = FacilityId.CleanFacilityId(input);
+        var cleanInput = FacilityId.CleanPartialFacilityId(input);
         return string.IsNullOrWhiteSpace(cleanInput)
             ? predicate
             : predicate.And(entry => entry.FacilityId.Contains(cleanInput));

--- a/src/AppServices/Compliance/Fces/Search/FceSearchDto.cs
+++ b/src/AppServices/Compliance/Fces/Search/FceSearchDto.cs
@@ -63,7 +63,7 @@ public record FceSearchDto : ISearchDto<FceSearchDto>, ISearchDto, IDeleteStatus
 
     public FceSearchDto TrimAll() => this with
     {
-        PartialFacilityId = FacilityId.CleanFacilityId(PartialFacilityId),
+        PartialFacilityId = FacilityId.CleanPartialFacilityId(PartialFacilityId),
         Notes = Notes?.Trim(),
     };
 }

--- a/src/AppServices/Compliance/WorkEntries/Search/WorkEntrySearchDto.cs
+++ b/src/AppServices/Compliance/WorkEntries/Search/WorkEntrySearchDto.cs
@@ -96,7 +96,7 @@ public record WorkEntrySearchDto : ISearchDto<WorkEntrySearchDto>, ISearchDto, I
 
     public WorkEntrySearchDto TrimAll() => this with
     {
-        PartialFacilityId = FacilityId.CleanFacilityId(PartialFacilityId),
+        PartialFacilityId = FacilityId.CleanPartialFacilityId(PartialFacilityId),
         Notes = Notes?.Trim(),
     };
 }

--- a/src/AppServices/Enforcement/Search/CaseFileSearchDto.cs
+++ b/src/AppServices/Enforcement/Search/CaseFileSearchDto.cs
@@ -79,7 +79,7 @@ public record CaseFileSearchDto : ISearchDto<CaseFileSearchDto>, ISearchDto, IDe
 
     public CaseFileSearchDto TrimAll() => this with
     {
-        PartialFacilityId = FacilityId.CleanFacilityId(PartialFacilityId),
+        PartialFacilityId = FacilityId.CleanPartialFacilityId(PartialFacilityId),
         Notes = Notes?.Trim(),
     };
 }

--- a/src/WebApp/Pages/Facility/Details.cshtml
+++ b/src/WebApp/Pages/Facility/Details.cshtml
@@ -215,7 +215,7 @@
                 <h2 class="mb-0">Recent Source Tests</h2>
             </div>
             <div class="col-auto ms-md-3 d-print-none">
-                <a asp-page="/Facility/SourceTests" asp-route-FacilityId="@Model.Id"
+                <a asp-page="/Facility/SourceTests" asp-route-Id="@Model.Id"
                    class="link-offset-2 link-underline-opacity-25 link-underline-opacity-75-hover">
                     View All
                 </a>

--- a/src/WebApp/Pages/Facility/Details.cshtml.cs
+++ b/src/WebApp/Pages/Facility/Details.cshtml.cs
@@ -50,13 +50,16 @@ public class DetailsModel(
             return RedirectToPage();
         }
 
-        if (Id is null) return NotFound("Facility ID not found.");
-        Facility = await facilityService.FindFacilityDetailsAsync((FacilityId)Id, RefreshIaipData);
+        if (!FacilityId.TryParse(Id, out var facilityId)) return NotFound("Facility ID not found.");
+
+        if (facilityId.FormattedId != Id) return RedirectToPage(new { id = facilityId });
+
+        Facility = await facilityService.FindFacilityDetailsAsync(facilityId, RefreshIaipData);
         if (Facility is null) return NotFound("Facility ID not found.");
 
         // Source Test service can be run in parallel with the search services.
         var sourceTestsForFacilityTask =
-            sourceTestService.GetSourceTestsForFacilityAsync((FacilityId)Id, RefreshIaipData);
+            sourceTestService.GetSourceTestsForFacilityAsync(facilityId, RefreshIaipData);
 
         // Search services cannot be run in parallel with each other when using Entity Framework.
         var searchWorkEntries = await entrySearchService.SearchAsync(

--- a/src/WebApp/Pages/Facility/Index.cshtml
+++ b/src/WebApp/Pages/Facility/Index.cshtml
@@ -10,11 +10,11 @@
 <form method="post" class="row my-3" role="search">
     <label class="visually-hidden" for="FindId">Find by Facility ID</label>
     <div class="input-group w-auto my-2">
-        <input id="FindId" asp-for="FindId" type="search" aria-label="Search"
+        <input id="FindId" asp-for="Id" type="search" aria-label="Search"
                placeholder="Find by Facility ID" class="form-control" />
         <button class="btn btn-primary" type="submit">View</button>
     </div>
-    <span asp-validation-for="FindId" class="text-danger-emphasis"></span>
+    <span asp-validation-for="Id" class="text-danger-emphasis"></span>
 </form>
 
 @if (AppSettings.DevSettings.UseDevSettings && AppSettings.DevSettings.UseInMemoryIaipData)

--- a/src/WebApp/Pages/Facility/Index.cshtml.cs
+++ b/src/WebApp/Pages/Facility/Index.cshtml.cs
@@ -15,10 +15,8 @@ public class IndexModel(IFacilityService service) : PageModel
 
     [BindProperty]
     [Required(ErrorMessage = "Enter a facility ID.")]
-    [RegularExpression(FacilityId.FacilityIdEnclosedPattern, ErrorMessage = FacilityIdFormatError)]
-    public string? FindId { get; set; }
-
-    private const string FacilityIdFormatError = "The Facility ID entered is not valid.";
+    [RegularExpression(FacilityId.FacilityIdEnclosedPattern, ErrorMessage = FacilityId.FacilityIdFormatError)]
+    public string? Id { get; set; }
 
     public async Task<IActionResult> OnGetAsync([FromQuery] bool refresh = false)
     {
@@ -40,14 +38,14 @@ public class IndexModel(IFacilityService service) : PageModel
             return Page();
         }
 
-        if (FindId == null || !FacilityId.IsValidFormat(FindId))
-            ModelState.AddModelError(nameof(FindId), FacilityIdFormatError);
-        else if (!await service.ExistsAsync((FacilityId)FindId))
-            ModelState.AddModelError(nameof(FindId),
+        if (Id == null || !FacilityId.IsValidFormat(Id))
+            ModelState.AddModelError(nameof(Id), FacilityId.FacilityIdFormatError);
+        else if (!await service.ExistsAsync((FacilityId)Id))
+            ModelState.AddModelError(nameof(Id),
                 "A Facility with that ID does not exist or has not been approved in the IAIP.");
 
         if (ModelState.IsValid)
-            return RedirectToPage("Details", routeValues: new { facilityId = FindId });
+            return RedirectToPage("Details", routeValues: new { id = Id });
 
         Facilities = await service.GetListAsync(RefreshIaipData);
         return Page();

--- a/src/WebApp/Pages/Facility/SourceTests.cshtml
+++ b/src/WebApp/Pages/Facility/SourceTests.cshtml
@@ -1,4 +1,4 @@
-﻿@page "{facilityId?}"
+﻿@page "{id?}"
 @using AirWeb.WebApp.Platform.Settings
 @model SourceTestsModel
 @{
@@ -34,7 +34,7 @@ else
                         </small>
                     </div>
                     <div class="col-auto my-0 ms-3">
-                        <a asp-route-facilityId="@Model.FacilityId" asp-route-refresh="true"
+                        <a asp-route-facilityId="@Model.Id" asp-route-refresh="true"
                            class="btn btn-sm btn-outline-info icon-link">
                             <svg class="bi">
                                 <use href="/images/app-icons.svg#app-icon-arrow-clockwise"></use>

--- a/src/WebApp/Pages/Facility/SourceTests.cshtml.cs
+++ b/src/WebApp/Pages/Facility/SourceTests.cshtml.cs
@@ -10,7 +10,7 @@ namespace AirWeb.WebApp.Pages.Facility;
 public class SourceTestsModel(IFacilityService facilityService, ISourceTestService sourceTestService) : PageModel
 {
     [FromRoute]
-    public string? FacilityId { get; set; }
+    public string? Id { get; set; }
 
     public IaipDataService.Facilities.Facility? Facility { get; private set; }
     public IList<SourceTestSummary> SourceTests { get; private set; } = [];
@@ -26,11 +26,14 @@ public class SourceTestsModel(IFacilityService facilityService, ISourceTestServi
             return RedirectToPage();
         }
 
-        if (FacilityId is null) return NotFound("Facility ID not found.");
-        Facility = await facilityService.FindFacilityDetailsAsync((FacilityId)FacilityId, RefreshIaipData);
+        if (!FacilityId.TryParse(Id, out var facilityId)) return NotFound("Facility ID not found.");
+
+        if (facilityId.FormattedId != Id) return RedirectToPage(new { id = facilityId });
+
+        Facility = await facilityService.FindFacilityDetailsAsync(facilityId, RefreshIaipData);
         if (Facility is null) return NotFound("Facility ID not found.");
 
-        SourceTests = (await sourceTestService.GetSourceTestsForFacilityAsync((FacilityId)FacilityId, RefreshIaipData))
+        SourceTests = (await sourceTestService.GetSourceTestsForFacilityAsync(facilityId, RefreshIaipData))
             .Take(GlobalConstants.PageSize).ToList();
 
         return Page();

--- a/tests/IaipDataServiceTests/FacilityIdTests.cs
+++ b/tests/IaipDataServiceTests/FacilityIdTests.cs
@@ -7,26 +7,95 @@ namespace IaipDataServiceTests;
 public class FacilityIdTests
 {
     [Test]
-    [TestCase("")]
-    [TestCase("1")]
-    [TestCase("0010001")]
-    [TestCase("001-0001")]
-    [TestCase("AAA-BBBBB")]
-    public void InvalidIdFormat_Throws(string input)
+    [TestCase("00100001")]
+    [TestCase("00110000")]
+    [TestCase("00199999")]
+    [TestCase("32100001")]
+    [TestCase("32110000")]
+    [TestCase("32199999")]
+    [TestCase("77700001")]
+    [TestCase("77710000")]
+    [TestCase("77799999")]
+    [TestCase("001-00001")]
+    [TestCase("001-10000")]
+    [TestCase("001-99999")]
+    [TestCase("321-00001")]
+    [TestCase("321-10000")]
+    [TestCase("321-99999")]
+    [TestCase("777-00001")]
+    [TestCase("777-10000")]
+    [TestCase("777-99999")]
+    [TestCase("1-1")]
+    [TestCase("1-10")]
+    [TestCase("1-10000")]
+    [TestCase("1-99999")]
+    [TestCase("321-1")]
+    [TestCase("777-1")]
+    [TestCase("321-10")]
+    [TestCase("777-10")]
+    [TestCase("1-01")]
+    [TestCase("1-10")]
+    [TestCase("1-001")]
+    [TestCase("1-0001")]
+    [TestCase("1-00001")]
+    [TestCase("01-1")]
+    [TestCase("01-10")]
+    [TestCase("01-99999")]
+    [TestCase("041300100001")]
+    public void IsValidFormat_ValidIdFormat_Accepted(string input)
     {
-        var func = () => new FacilityId(input);
-        func.Should().Throw<ArgumentException>();
+        FacilityId.IsValidFormat(input).Should().BeTrue();
     }
 
     [Test]
-    [TestCase("00100001")]
-    [TestCase("001-00001")]
-    public void ValidIdFormat_Succeeds(string input)
+    [TestCase("")]
+    [TestCase("111")]
+    [TestCase("ABC")]
+    [TestCase("04130010000")]
+    [TestCase("041300200001")]
+    [TestCase("041332300001")]
+    [TestCase("041300000001")]
+    [TestCase("041300100000")]
+    [TestCase("04-13-001-00001")]
+    [TestCase("0413-001-0001")]
+    [TestCase("abc-defgh")]
+    [TestCase("001-0000a")]
+    [TestCase("0100001")]
+    [TestCase("0010001")]
+    [TestCase("00200001")]
+    [TestCase("002-00001")]
+    [TestCase("2-1")]
+    [TestCase("32300001")]
+    [TestCase("323-00001")]
+    [TestCase("323-1")]
+    [TestCase("00000001")]
+    [TestCase("000-00001")]
+    [TestCase("000-99999")]
+    [TestCase("0-1")]
+    [TestCase("00100000")]
+    [TestCase("001-00000")]
+    [TestCase("001-0")]
+    [TestCase("1-0")]
+    public void IsValidFormat_InvalidIdFormat_Rejected(string input)
     {
-        var result = new FacilityId(input);
+        FacilityId.IsValidFormat(input).Should().BeFalse();
+    }
+
+    [Test]
+    public void Normalize_ValidIdFormat_SucceedsAndNormalizesId()
+    {
+        var result = new FacilityId("1-1");
         result.Id.Should().Be("00100001");
         result.FormattedId.Should().Be("001-00001");
+        result.ToString().Should().Be("001-00001");
         result.EpaFacilityIdentifier.Should().Be("GA0000001300100001");
+    }
+
+    [Test]
+    public void Normalize_InvalidIdFormat_Throws()
+    {
+        var func = () => new FacilityId("0-1");
+        func.Should().Throw<ArgumentException>();
     }
 
     [Test]
@@ -36,8 +105,6 @@ public class FacilityIdTests
     {
         var result = (FacilityId)input;
         result.Id.Should().Be("00100001");
-        result.FormattedId.Should().Be("001-00001");
-        result.EpaFacilityIdentifier.Should().Be("GA0000001300100001");
     }
 
     [Test]
@@ -47,5 +114,74 @@ public class FacilityIdTests
     {
         string result = new FacilityId(input);
         result.Should().Be("001-00001");
+    }
+
+    [Test]
+    public void Equals_WhenEqual_ReturnsTrue()
+    {
+        var value1 = new FacilityId("1-1");
+        var value2 = new FacilityId("041300100001");
+        value1.Equals(value2).Should().BeTrue();
+    }
+
+    [Test]
+    public void Equals_WhenNotEqual_ReturnsFalse()
+    {
+        var value1 = new FacilityId("1-1");
+        var value2 = new FacilityId("1-2");
+        value1.Equals(value2).Should().BeFalse();
+    }
+
+    [Test]
+    public void TryParse_ValidIdFormat_Succeeds()
+    {
+        var result = FacilityId.TryParse("1-1", out var facilityId);
+        result.Should().BeTrue();
+        facilityId.Should().NotBeNull();
+        facilityId.Id.Should().Be("00100001");
+    }
+
+    [Test]
+    public void TryParse_InvalidIdFormat_Fails()
+    {
+        var result = FacilityId.TryParse("0-1", out var facilityId);
+        result.Should().BeFalse();
+        facilityId.Should().BeNull();
+    }
+
+    [Test]
+    public void TryParse_NullInput_Fails()
+    {
+        var result = FacilityId.TryParse(null, out var facilityId);
+        result.Should().BeFalse();
+        facilityId.Should().BeNull();
+    }
+
+    [Test]
+    [TestCase("1-1", "1-1")]
+    [TestCase("11", "11")]
+    [TestCase("a", "")]
+    [TestCase("a1-", "1-")]
+    [TestCase("001-00001", "001-00001")]
+    public void CleanFacilityId_PartialId_ReturnsCleanedValue(string input, string expected)
+    {
+        FacilityId.CleanPartialFacilityId(input).Should().Be(expected);
+    }
+
+    [Test]
+    [TestCase("00100001", "001-00001")]
+    [TestCase("00000000", "000-00000")]
+    public void CleanFacilityId_FullId_ReturnsFormattedValue(string input, string expected)
+    {
+        FacilityId.CleanPartialFacilityId(input).Should().Be(expected);
+    }
+
+    [Test]
+    [TestCase("")]
+    [TestCase(null)]
+    public void CleanFacilityId_EmptyId_ReturnsEmptyString(string? input)
+    {
+        var result = FacilityId.CleanPartialFacilityId(input);
+        result.Should().Be(string.Empty);
     }
 }


### PR DESCRIPTION
- The Facility ID regex is updated to make leading zeros optional.
- Pages with a Facility ID in the route redirect to a canonical version with a normalized, formatted AIRS number.