### PR TITLE
Change the assembly name

### DIFF
--- a/docs/Workflows/Enforcement-workflow.md
+++ b/docs/Workflows/Enforcement-workflow.md
@@ -150,8 +150,8 @@ flowchart
 ```mermaid
 flowchart
     ENF{{Case File}}
-    PCO{{"`Enforcement Action: **Proposed Consent Order**`"}}
-    CO{{"`Enforcement Action: **Consent Order**`"}}
+    PCO{{"`**Proposed CO**`"}}
+    CO{{"`**Consent Order**`"}}
     STP{{Stipulated Penalty}}
     addPCO([Add Proposed CO])
     issuePCO([Issue PCO])

--- a/src/WebApp/WebApp.csproj
+++ b/src/WebApp/WebApp.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <InformationalVersion>2024.8.27</InformationalVersion>
         <RootNamespace>AirWeb.WebApp</RootNamespace>
+        <AssemblyName>AirWeb.WebApp</AssemblyName>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Server monitoring software uses the assembly name to differentiate events between applications.