### PR TITLE
450 remove colon when enforcement action response received but no notes are entered

### DIFF
--- a/src/WebApp/Pages/Enforcement/_Partials/_ResponseRequestedDetails.cshtml
+++ b/src/WebApp/Pages/Enforcement/_Partials/_ResponseRequestedDetails.cshtml
@@ -6,12 +6,9 @@
     {
         <div class="mb-1">
             <em>
-				Response received
-				@Html.DisplayFor(_ => Model.ResponseReceived, DisplayTemplate.ShortDateOnlyNullable)
-				@if (Model.ResponseComment != null)
-				{
-					<text>:</text>
-				}
+                Response received
+                @Html.DisplayFor(_ => Model.ResponseReceived, DisplayTemplate.ShortDateOnlyNullable)
+                @if (Model.ResponseComment != null){<text>:</text>}
             </em>
         </div>
         if (Model.ResponseComment != null)


### PR DESCRIPTION
Colon was removed if there are not Response Comments 
<img width="1164" height="804" alt="image" src="https://github.com/user-attachments/assets/e8a83aa9-84aa-469c-b503-588c5f920635" />
