### PR TITLE
format search result counts with thousand separators

### DIFF
--- a/src/WebApp/Pages/Shared/_PaginationNavAndCount.cshtml
+++ b/src/WebApp/Pages/Shared/_PaginationNavAndCount.cshtml
@@ -3,11 +3,11 @@
 <div class="container px-0 py-2">
     <div class="row">
         <div class="small col-md mt-3 text-secondary-emphasis">
-            Total: @Html.DisplayFor(_ => Model.SearchResults.TotalCount)
+            Total: @Model.SearchResults.TotalCount.ToString("N0")
             @if (Model.SearchResults.TotalPages > 1)
             {
                 <br />
-                @:Showing: @Model.SearchResults.FirstItemIndex.ToString() – @Model.SearchResults.LastItemIndex.ToString()
+                @:Showing: @Model.SearchResults.FirstItemIndex.ToString("N0") – @Model.SearchResults.LastItemIndex.ToString("N0")
             }
         </div>
         <div class="col-md">


### PR DESCRIPTION
- added the `"N0"` string format specifier to the pagination component (`_Pagination.cshtml`) to ensure that large numbers are displayed with thousand separators

closes #494
