### PR TITLE
469 convert abbreviated facility id to full facility id on search pages

### DIFF
--- a/src/AppServices.Compliance/Compliance/ComplianceMonitoring/Search/ComplianceWorkSearchDto.cs
+++ b/src/AppServices.Compliance/Compliance/ComplianceMonitoring/Search/ComplianceWorkSearchDto.cs
@@ -26,17 +26,14 @@ public record ComplianceWorkSearchDto : ISearchDto<ComplianceWorkSearchDto>, ISe
 
     // == Facility ==
 
-    private string? _facilityId;
-
     [Display(Name = "Facility AIRS Number")]
     [StringLength(9)]
     [RegularExpression(IaipDataService.Facilities.FacilityId.SimplifiedFormat,
         ErrorMessage = IaipDataService.Facilities.FacilityId.SimplifiedFormatError)]
     public string? FacilityId
     {
-        get => _facilityId;
-        init => _facilityId = IaipDataService.Facilities.FacilityId
-            .FacilityIdFormatter.Format(value);
+        get;
+        init => field = IaipDataService.Facilities.FacilityId.TryFormat(value);
     }
 
     // == Staff ==

--- a/src/AppServices.Compliance/Compliance/ComplianceMonitoring/Search/ComplianceWorkSearchDto.cs
+++ b/src/AppServices.Compliance/Compliance/ComplianceMonitoring/Search/ComplianceWorkSearchDto.cs
@@ -26,11 +26,18 @@ public record ComplianceWorkSearchDto : ISearchDto<ComplianceWorkSearchDto>, ISe
 
     // == Facility ==
 
+    private string? _facilityId;
+
     [Display(Name = "Facility AIRS Number")]
     [StringLength(9)]
     [RegularExpression(IaipDataService.Facilities.FacilityId.SimplifiedFormat,
         ErrorMessage = IaipDataService.Facilities.FacilityId.SimplifiedFormatError)]
-    public string? FacilityId { get; init; }
+    public string? FacilityId
+    {
+        get => _facilityId;
+        init => _facilityId = IaipDataService.Facilities.FacilityId
+            .FacilityIdFormatter.Format(value);
+    }
 
     // == Staff ==
 

--- a/src/AppServices.Compliance/Compliance/Fces/Search/FceSearchDto.cs
+++ b/src/AppServices.Compliance/Compliance/Fces/Search/FceSearchDto.cs
@@ -15,8 +15,6 @@ public record FceSearchDto : ISearchDto<FceSearchDto>, ISearchDto, IDeleteStatus
     [Display(Name = "Deletion Status")]
     public DeleteStatus? DeleteStatus { get; set; }
 
-    // == Facility ==
-
     private string? _facilityId;
 
     [Display(Name = "Facility AIRS Number")]

--- a/src/AppServices.Compliance/Compliance/Fces/Search/FceSearchDto.cs
+++ b/src/AppServices.Compliance/Compliance/Fces/Search/FceSearchDto.cs
@@ -15,17 +15,14 @@ public record FceSearchDto : ISearchDto<FceSearchDto>, ISearchDto, IDeleteStatus
     [Display(Name = "Deletion Status")]
     public DeleteStatus? DeleteStatus { get; set; }
 
-    private string? _facilityId;
-
     [Display(Name = "Facility AIRS Number")]
     [StringLength(9)]
     [RegularExpression(IaipDataService.Facilities.FacilityId.SimplifiedFormat,
         ErrorMessage = IaipDataService.Facilities.FacilityId.SimplifiedFormatError)]
     public string? FacilityId
     {
-        get => _facilityId;
-        init => _facilityId = IaipDataService.Facilities.FacilityId
-            .FacilityIdFormatter.Format(value);
+        get;
+        init => field = IaipDataService.Facilities.FacilityId.TryFormat(value);
     }
 
     [Display(Name = "FCE Year")]

--- a/src/AppServices.Compliance/Compliance/Fces/Search/FceSearchDto.cs
+++ b/src/AppServices.Compliance/Compliance/Fces/Search/FceSearchDto.cs
@@ -15,11 +15,20 @@ public record FceSearchDto : ISearchDto<FceSearchDto>, ISearchDto, IDeleteStatus
     [Display(Name = "Deletion Status")]
     public DeleteStatus? DeleteStatus { get; set; }
 
+    // == Facility ==
+
+    private string? _facilityId;
+
     [Display(Name = "Facility AIRS Number")]
     [StringLength(9)]
     [RegularExpression(IaipDataService.Facilities.FacilityId.SimplifiedFormat,
         ErrorMessage = IaipDataService.Facilities.FacilityId.SimplifiedFormatError)]
-    public string? FacilityId { get; init; }
+    public string? FacilityId
+    {
+        get => _facilityId;
+        init => _facilityId = IaipDataService.Facilities.FacilityId
+            .FacilityIdFormatter.Format(value);
+    }
 
     [Display(Name = "FCE Year")]
     public int? Year { get; init; }

--- a/src/AppServices.Compliance/Enforcement/Search/CaseFileSearchDto.cs
+++ b/src/AppServices.Compliance/Enforcement/Search/CaseFileSearchDto.cs
@@ -25,17 +25,14 @@ public record CaseFileSearchDto : ISearchDto<CaseFileSearchDto>, ISearchDto, IDe
 
     // == Facility ==
 
-    private string? _facilityId;
-
     [Display(Name = "Facility AIRS Number")]
     [StringLength(9)]
     [RegularExpression(IaipDataService.Facilities.FacilityId.SimplifiedFormat,
         ErrorMessage = IaipDataService.Facilities.FacilityId.SimplifiedFormatError)]
     public string? FacilityId
     {
-        get => _facilityId;
-        init => _facilityId = IaipDataService.Facilities.FacilityId
-            .FacilityIdFormatter.Format(value);
+        get;
+        init => field = IaipDataService.Facilities.FacilityId.TryFormat(value);
     }
     // == Staff ==
 

--- a/src/AppServices.Compliance/Enforcement/Search/CaseFileSearchDto.cs
+++ b/src/AppServices.Compliance/Enforcement/Search/CaseFileSearchDto.cs
@@ -25,12 +25,18 @@ public record CaseFileSearchDto : ISearchDto<CaseFileSearchDto>, ISearchDto, IDe
 
     // == Facility ==
 
+    private string? _facilityId;
+
     [Display(Name = "Facility AIRS Number")]
     [StringLength(9)]
     [RegularExpression(IaipDataService.Facilities.FacilityId.SimplifiedFormat,
         ErrorMessage = IaipDataService.Facilities.FacilityId.SimplifiedFormatError)]
-    public string? FacilityId { get; init; }
-
+    public string? FacilityId
+    {
+        get => _facilityId;
+        init => _facilityId = IaipDataService.Facilities.FacilityId
+            .FacilityIdFormatter.Format(value);
+    }
     // == Staff ==
 
     [Display(Name = "Staff Responsible")]

--- a/src/IaipDataService/Facilities/FacilityId.cs
+++ b/src/IaipDataService/Facilities/FacilityId.cs
@@ -115,21 +115,16 @@ public partial record FacilityId
     {
         public static string? Format(string? input)
         {
+
             if (string.IsNullOrWhiteSpace(input))
                 return input;
 
-            var parts = input.Split('-');
-
-            // check to see if both parts are integers
-            if (!int.TryParse(parts[0], out int part1))
-                return input;
-
-            //default part2 to 0 means 5 => 005-0000
-            int part2 = 0;
-            if (parts.Length > 1)
-                int.TryParse(parts[1], out part2);
-
-            return $"{part1:D3}-{part2:D4}";
+            if (FacilityId.TryParse(input, out var facilityId))
+            {
+                return facilityId.FormattedId;
+            }
+            // If FacilityId does not exist, return original input
+            return input;
         }
     }
 }

--- a/src/IaipDataService/Facilities/FacilityId.cs
+++ b/src/IaipDataService/Facilities/FacilityId.cs
@@ -110,4 +110,26 @@ public partial record FacilityId
     // language:regex
     public const string SimplifiedFormat = "[0-9]{1,3}-[0-9]{1,5}|[0-9]{8}";
     public const string SimplifiedFormatError = "Invalid AIRS Number format.";
+
+    public static class FacilityIdFormatter
+    {
+        public static string? Format(string? input)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+                return input;
+
+            var parts = input.Split('-');
+
+            // check to see if both parts are integers
+            if (!int.TryParse(parts[0], out int part1))
+                return input;
+
+            //default part2 to 0 means 5 => 005-0000
+            int part2 = 0;
+            if (parts.Length > 1)
+                int.TryParse(parts[1], out part2);
+
+            return $"{part1:D3}-{part2:D4}";
+        }
+    }
 }

--- a/src/IaipDataService/Facilities/FacilityId.cs
+++ b/src/IaipDataService/Facilities/FacilityId.cs
@@ -49,7 +49,7 @@ public partial record FacilityId
 
     public static bool TryParse([NotNullWhen(true)] string? s, [NotNullWhen(true)] out FacilityId? result)
     {
-        if (s is null)
+        if (string.IsNullOrEmpty(s))
         {
             result = null;
             return false;
@@ -111,20 +111,7 @@ public partial record FacilityId
     public const string SimplifiedFormat = "[0-9]{1,3}-[0-9]{1,5}|[0-9]{8}";
     public const string SimplifiedFormatError = "Invalid AIRS Number format.";
 
-    public static class FacilityIdFormatter
-    {
-        public static string? Format(string? input)
-        {
-
-            if (string.IsNullOrWhiteSpace(input))
-                return input;
-
-            if (FacilityId.TryParse(input, out var facilityId))
-            {
-                return facilityId.FormattedId;
-            }
-            // If FacilityId does not exist, return original input
-            return input;
-        }
-    }
+    // Format as Facility ID if possible, otherwise return original input.
+    public static string? TryFormat(string? input) =>
+        TryParse(input, out var facilityId) ? facilityId.FormattedId : input;
 }

--- a/tests/IaipDataServiceTests/Models/FacilityIdTests.cs
+++ b/tests/IaipDataServiceTests/Models/FacilityIdTests.cs
@@ -156,4 +156,32 @@ public class FacilityIdTests
         result.Should().BeFalse();
         facilityId.Should().BeNull();
     }
+
+    [Test]
+    public void TryFormat_ValidIdFormat_ReturnsFormatted()
+    {
+        var result = FacilityId.TryFormat("1-1");
+        result.Should().Be("001-00001");
+    }
+
+    [Test]
+    public void TryFormat_InvalidIdFormat_ReturnsOriginal()
+    {
+        var result = FacilityId.TryFormat("0-1");
+        result.Should().Be("0-1");
+    }
+
+    [Test]
+    public void TryFormat_EmptyString_ReturnsEmptyString()
+    {
+        var result = FacilityId.TryFormat(string.Empty);
+        result.Should().BeEmpty();
+    }
+
+    [Test]
+    public void TryFormat_NullInput_ReturnsNull()
+    {
+        var result = FacilityId.TryFormat(null);
+        result.Should().BeNull();
+    }
 }


### PR DESCRIPTION
When search results are returned, facility id is formatted correctly (ex. 1-1 => 001-0001)