### PR TITLE
Improve useability of the facility search page filter

### DIFF
--- a/src/WebApp/Pages/Facility/Index.cshtml
+++ b/src/WebApp/Pages/Facility/Index.cshtml
@@ -79,15 +79,19 @@ else
             const originalList = document.getElementById('facility-list');
             const originalListItems = originalList.getElementsByTagName('li');
             const filteredList = document.getElementById('filtered-facility-list');
+            let count = 0;
 
-            filterInput.addEventListener('keydown', (event) => {
-                if (event.key === 'Enter') { event.preventDefault(); }
+            filterInput.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') {
+                    if (count == 1) filteredList.querySelector('a').click();
+                    e.preventDefault();
+                }
             });
 
             filterInput.addEventListener('input', () => {
                 const filter = filterInput.value.toLowerCase();
                 const fragment = document.createDocumentFragment();
-                let count = 0;
+                count = 0;
 
                 for (let i = 0; i < originalListItems.length; i++) {
                     const a = originalListItems[i].getElementsByTagName('a')[0];

--- a/src/WebApp/Pages/Facility/Index.cshtml
+++ b/src/WebApp/Pages/Facility/Index.cshtml
@@ -42,7 +42,8 @@ else
     <label class="visually-hidden" for="facility-list-filter">Filter facility list</label>
     <div class="row row-cols-auto g-2 align-items-center">
         <div>
-            <input id="facility-list-filter" class="form-control form-control-sm col-12 w-auto" placeholder="Filter facility list" aria-describedby="filtered-facility-list-count" />
+            <input id="facility-list-filter" class="form-control form-control-sm col-12 w-auto" 
+                placeholder="Filter facility list" aria-describedby="filtered-facility-list-count" />
         </div>
         <div>
         <span id="filtered-facility-list-count" class="form-text col-12 text-body-secondary">
@@ -78,6 +79,10 @@ else
             const originalList = document.getElementById('facility-list');
             const originalListItems = originalList.getElementsByTagName('li');
             const filteredList = document.getElementById('filtered-facility-list');
+
+            filterInput.addEventListener('keydown', (event) => {
+                if (event.key === 'Enter') { event.preventDefault(); }
+            });
 
             filterInput.addEventListener('input', () => {
                 const filter = filterInput.value.toLowerCase();


### PR DESCRIPTION
The page shouldn't reload when the <kbd>Enter</kbd> key is hit. If the list has been filtered to a single facility, navigate to that facility.