### PR TITLE
Remove violation type DB table

### DIFF
--- a/src/AppServices.Compliance/Enforcement/CaseFileService.cs
+++ b/src/AppServices.Compliance/Enforcement/CaseFileService.cs
@@ -66,7 +66,7 @@ public sealed class CaseFileService(
     public async Task<CaseFileSummaryDto?> FindSummaryAsync(int id, CancellationToken token = default)
     {
         var caseFile = mapper.Map<CaseFileSummaryDto?>(await caseFileRepository
-            .FindAsync(id, includeProperties: [nameof(CaseFile.ViolationType), nameof(CaseFile.EnforcementActions)],
+            .FindAsync(id, includeProperties: [nameof(CaseFile.EnforcementActions)],
                 token: token).ConfigureAwait(false));
 
         caseFile?.FacilityName = await facilityService.GetNameAsync((FacilityId)caseFile.FacilityId)
@@ -118,8 +118,7 @@ public sealed class CaseFileService(
         caseFile.ResponsibleStaff = await userService.FindUserAsync(resource.ResponsibleStaffId!).ConfigureAwait(false);
         caseFile.DiscoveryDate = resource.DiscoveryDate;
         caseFile.Notes = resource.Notes ?? string.Empty;
-        caseFile.ViolationType = await caseFileRepository.GetViolationTypeAsync(resource.ViolationTypeCode, token)
-            .ConfigureAwait(false);
+        caseFile.ViolationTypeCode = resource.ViolationTypeCode;
 
         caseFileManager.Update(caseFile, currentUser);
         await caseFileRepository.UpdateAsync(caseFile, token: token).ConfigureAwait(false);
@@ -147,7 +146,7 @@ public sealed class CaseFileService(
 
     public async Task<bool> LinkComplianceEventAsync(int caseFileId, int eventId, CancellationToken token = default)
     {
-        var caseFile = await caseFileRepository.GetAsync(caseFileId, 
+        var caseFile = await caseFileRepository.GetAsync(caseFileId,
             includeProperties: [nameof(CaseFile.ComplianceEvents), nameof(CaseFile.EnforcementActions)],
             token: token).ConfigureAwait(false);
         if (await repository.GetAsync(eventId, token: token).ConfigureAwait(false) is not ComplianceEvent ce)
@@ -164,9 +163,9 @@ public sealed class CaseFileService(
     public async Task<bool> UnLinkComplianceEventAsync(int caseFileId, int eventId, bool autoSave = true,
         CancellationToken token = default)
     {
-        var caseFile = await caseFileRepository.GetAsync(caseFileId, 
-            includeProperties: [nameof(CaseFile.ComplianceEvents), nameof(CaseFile.EnforcementActions)],
-            token: token)
+        var caseFile = await caseFileRepository.GetAsync(caseFileId,
+                includeProperties: [nameof(CaseFile.ComplianceEvents), nameof(CaseFile.EnforcementActions)],
+                token: token)
             .ConfigureAwait(false);
         if (await repository.GetAsync(eventId, token: token).ConfigureAwait(false) is not ComplianceEvent ce)
             return false;
@@ -189,19 +188,18 @@ public sealed class CaseFileService(
         IEnumerable<string> airPrograms, string? violationTypeCode, CancellationToken token = default)
     {
         var caseFile = await caseFileRepository.GetAsync(id,
-            includeProperties: [nameof(CaseFile.EnforcementActions), nameof(CaseFile.ComplianceEvents)], 
+            includeProperties: [nameof(CaseFile.EnforcementActions), nameof(CaseFile.ComplianceEvents)],
             token: token).ConfigureAwait(false);
         var currentUser = await userService.GetCurrentUserAsync().ConfigureAwait(false);
 
-        caseFile.ViolationType =
-            await caseFileRepository.GetViolationTypeAsync(violationTypeCode, token).ConfigureAwait(false);
+        caseFile.ViolationTypeCode = violationTypeCode;
         caseFileManager.UpdatePollutantsAndPrograms(caseFile, pollutants, airPrograms, currentUser);
         await caseFileRepository.UpdateAsync(caseFile, token: token).ConfigureAwait(false);
     }
 
     public async Task<CommandResult> CloseAsync(int id, CancellationToken token = default)
     {
-        var caseFile = await caseFileRepository.GetAsync(id, 
+        var caseFile = await caseFileRepository.GetAsync(id,
             includeProperties: [nameof(CaseFile.ComplianceEvents), nameof(CaseFile.EnforcementActions)],
             token: token).ConfigureAwait(false);
         var currentUser = await userService.GetCurrentUserAsync().ConfigureAwait(false);
@@ -237,7 +235,7 @@ public sealed class CaseFileService(
     public async Task<CommandResult> DeleteAsync(int id, NotesDto resource,
         CancellationToken token = default)
     {
-        var caseFile = await caseFileRepository.GetAsync(id, 
+        var caseFile = await caseFileRepository.GetAsync(id,
             includeProperties: [nameof(CaseFile.ComplianceEvents), nameof(CaseFile.EnforcementActions)],
             token: token).ConfigureAwait(false);
         var currentUser = await userService.GetCurrentUserAsync().ConfigureAwait(false);
@@ -255,7 +253,7 @@ public sealed class CaseFileService(
 
     public async Task<CommandResult> RestoreAsync(int id, CancellationToken token = default)
     {
-        var caseFile = await caseFileRepository.GetAsync(id, 
+        var caseFile = await caseFileRepository.GetAsync(id,
             includeProperties: [nameof(CaseFile.ComplianceEvents), nameof(CaseFile.EnforcementActions)],
             token: token).ConfigureAwait(false);
         var currentUser = await userService.GetCurrentUserAsync().ConfigureAwait(false);

--- a/src/AppServices.Compliance/Enforcement/EnforcementActionService.cs
+++ b/src/AppServices.Compliance/Enforcement/EnforcementActionService.cs
@@ -179,7 +179,6 @@ public sealed class EnforcementActionService(
             includeProperties:
             [
                 nameof(EnforcementAction.CaseFile),
-                $"{nameof(CaseFile)}.{nameof(CaseFile.ViolationType)}",
                 $"{nameof(CaseFile)}.{nameof(CaseFile.ComplianceEvents)}",
             ],
             token: token).ConfigureAwait(false);

--- a/src/AppServices.Compliance/Enforcement/Search/CaseFileExportDto.cs
+++ b/src/AppServices.Compliance/Enforcement/Search/CaseFileExportDto.cs
@@ -14,9 +14,7 @@ public record CaseFileExportDto : IFacilitySearchResult
         FacilityId = caseFile.FacilityId;
         ResponsibleStaff = caseFile.ResponsibleStaff?.SortableFullName;
         CaseFileStatus = caseFile.CaseFileStatus.GetDisplayName();
-        ViolationType = caseFile.ViolationType == null
-            ? ""
-            : caseFile.ViolationType.Display;
+        ViolationType = caseFile.ViolationType == null ? "" : caseFile.ViolationType.Display;
         DiscoveryDate = caseFile.DiscoveryDate;
         DayZero = caseFile.DayZero;
         EnforcementDate = caseFile.EnforcementDate;

--- a/src/AppServices.Compliance/Enforcement/Search/CaseFileFilters.cs
+++ b/src/AppServices.Compliance/Enforcement/Search/CaseFileFilters.cs
@@ -53,8 +53,8 @@ internal static class CaseFileFilters
         input is null
             ? predicate
             : predicate.And(caseFile =>
-                caseFile.ViolationType != null &&
-                caseFile.ViolationType.Code == input);
+                caseFile.ViolationTypeCode != null &&
+                caseFile.ViolationTypeCode == input);
 
     public static Expression<Func<CaseFile, bool>> MinDiscoveryDate(
         this Expression<Func<CaseFile, bool>> predicate,

--- a/src/Domain.Compliance/EnforcementEntities/CaseFiles/CaseFile.cs
+++ b/src/Domain.Compliance/EnforcementEntities/CaseFiles/CaseFile.cs
@@ -37,7 +37,10 @@ public class CaseFile : ClosableEntity<int>, INotes, IDataExchangeAction, IComme
     public string? Notes { get; set; }
 
     // Required if the data exchange is enabled.
-    public ViolationType? ViolationType { get; set; }
+    [StringLength(5)]
+    public string? ViolationTypeCode { get; set; }
+
+    public ViolationType? ViolationType => ViolationTypeData.GetViolationType(ViolationTypeCode);
 
     // Status
 

--- a/src/Domain.Compliance/EnforcementEntities/CaseFiles/CaseFile.cs
+++ b/src/Domain.Compliance/EnforcementEntities/CaseFiles/CaseFile.cs
@@ -77,12 +77,12 @@ public class CaseFile : ClosableEntity<int>, INotes, IDataExchangeAction, IComme
 
     // Computed dates
 
-    // HPV Day Zero is required if the data exchange is enabled and the Violation Severity is "HPV".
+    // HPV Day Zero is required if the data exchange is enabled, and the Violation Severity is "HPV".
     public DateOnly? DayZero
     {
         get
         {
-            if (ViolationType is not { SeverityCode: "HPV" }) return null;
+            if (ViolationType is not { SeverityCode: ViolationSeverity.HPV }) return null;
             var actionDates = EnforcementActions
                 .Where(action => action.IsReportable)
                 .Select(action => action.IssueDate) // List the dates each formal enforcement action was issued.

--- a/src/Domain.Compliance/EnforcementEntities/CaseFiles/ICaseFileRepository.cs
+++ b/src/Domain.Compliance/EnforcementEntities/CaseFiles/ICaseFileRepository.cs
@@ -1,6 +1,4 @@
-﻿using AirWeb.Domain.Compliance.EnforcementEntities.ViolationTypes;
-
-namespace AirWeb.Domain.Compliance.EnforcementEntities.CaseFiles;
+﻿namespace AirWeb.Domain.Compliance.EnforcementEntities.CaseFiles;
 
 public interface ICaseFileRepository : IRepositoryWithMapping<CaseFile, int>
 {
@@ -16,9 +14,8 @@ public interface ICaseFileRepository : IRepositoryWithMapping<CaseFile, int>
     /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
     /// <returns>A Case File with included details or null.</returns>
     Task<CaseFile?> FindWithDetailsAsync(int id, CancellationToken token = default);
-    
+
     // Case File details
-    Task<ViolationType?> GetViolationTypeAsync(string? code, CancellationToken token = default);
     Task<IEnumerable<Pollutant>> GetPollutantsAsync(int id, CancellationToken token = default);
     Task<IEnumerable<AirProgram>> GetAirProgramsAsync(int id, CancellationToken token = default);
 }

--- a/src/Domain.Compliance/EnforcementEntities/ViolationTypes/ViolationType.cs
+++ b/src/Domain.Compliance/EnforcementEntities/ViolationTypes/ViolationType.cs
@@ -5,8 +5,6 @@ namespace AirWeb.Domain.Compliance.EnforcementEntities.ViolationTypes;
 
 public record ViolationType
 {
-    internal ViolationType() { }
-
     [Key]
     [StringLength(5)]
     public required string Code { get; init; }

--- a/src/Domain.Compliance/EnforcementEntities/ViolationTypes/ViolationType.cs
+++ b/src/Domain.Compliance/EnforcementEntities/ViolationTypes/ViolationType.cs
@@ -1,4 +1,7 @@
-﻿namespace AirWeb.Domain.Compliance.EnforcementEntities.ViolationTypes;
+﻿using GaEpd.AppLibrary.Extensions;
+using System.Diagnostics.CodeAnalysis;
+
+namespace AirWeb.Domain.Compliance.EnforcementEntities.ViolationTypes;
 
 public record ViolationType
 {
@@ -12,10 +15,27 @@ public record ViolationType
     public required string Description { get; init; }
 
     [StringLength(3)]
-    public required string SeverityCode { get; init; }
+    public required ViolationSeverity SeverityCode { get; init; }
 
     public bool Deprecated { get; init; }
-    public string Current => Deprecated ? "Historic" : "Current";
 
+    public string Current => Deprecated ? "Historic" : "Current";
     public string Display => $"{SeverityCode}: {Description} ({Code})";
+    public string SeverityCodeDisplay => SeverityCode.GetDisplayName();
+}
+
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+public enum ViolationSeverity
+{
+    [Display(Name = "High Priority Violation")]
+    HPV,
+
+    [Display(Name = "Federally Reportable Violation")]
+    FRV,
+
+    [Display(Name = "Federally Enforceable Violation but not Federally Reportable")]
+    NFR,
+
+    [Display(Name = "Other")]
+    OTH,
 }

--- a/src/Domain.Compliance/EnforcementEntities/ViolationTypes/ViolationTypeData.cs
+++ b/src/Domain.Compliance/EnforcementEntities/ViolationTypes/ViolationTypeData.cs
@@ -1,22 +1,9 @@
 ﻿namespace AirWeb.Domain.Compliance.EnforcementEntities.ViolationTypes;
 
-// ReSharper disable StringLiteralTypo
-// Source of data from IAIP DB:
-//
-// ```sql
-// select AIRVIOLATIONTYPECODE as Code,
-//        VIOLATIONTYPEDESC    as Description,
-//        SEVERITYCODE         as SeverityCode,
-//        lower(DEPRECATED)    as Deprecated
-// from dbo.LK_VIOLATION_TYPE
-// where STATUS = 'A'
-// order by SEVERITYCODE, DEPRECATED, VIOLATIONTYPEDESC
-// ```
-
 public static class ViolationTypeData
 {
     public static ViolationType? GetViolationType(string? code) =>
-        ViolationTypes.Find(type => type.Code == code);
+        code is null ? null : ViolationTypes.Find(type => type.Code == code);
 
     public static IReadOnlyList<ViolationType> GetAll() =>
         ViolationTypes
@@ -36,7 +23,7 @@ public static class ViolationTypeData
         ViolationTypes.Where(type => !type.Deprecated).OrderBy(_ => Guid.NewGuid()).First();
 
     // ReSharper disable StringLiteralTypo
-    public static List<ViolationType> ViolationTypes { get; } =
+    private static List<ViolationType> ViolationTypes { get; } =
     [
         new()
         {

--- a/src/Domain.Compliance/EnforcementEntities/ViolationTypes/ViolationTypeData.cs
+++ b/src/Domain.Compliance/EnforcementEntities/ViolationTypes/ViolationTypeData.cs
@@ -43,98 +43,98 @@ public static class ViolationTypeData
             Code = "FCIO",
             Description =
                 "Failure to construct, install or operate facility/equipment in accordance with permit or regulation",
-            SeverityCode = "FRV",
+            SeverityCode = ViolationSeverity.FRV,
             Deprecated = false,
         },
         new()
         {
             Code = "FMPR",
             Description = "Failure to maintain records as required by permit or regulation",
-            SeverityCode = "FRV",
+            SeverityCode = ViolationSeverity.FRV,
             Deprecated = false,
         },
         new()
         {
             Code = "FOMP",
             Description = "Failure to obtain or maintain a current permit",
-            SeverityCode = "FRV",
+            SeverityCode = ViolationSeverity.FRV,
             Deprecated = false,
         },
         new()
         {
             Code = "FRPR",
             Description = "Failure to report as required by permit or regulation",
-            SeverityCode = "FRV",
+            SeverityCode = ViolationSeverity.FRV,
             Deprecated = false,
         },
         new()
         {
             Code = "FTCM",
             Description = "Failure to test or conduct monitoring as required by permit or regulation",
-            SeverityCode = "FRV",
+            SeverityCode = ViolationSeverity.FRV,
             Deprecated = false,
         },
         new()
         {
             Code = "VDOA",
             Description = "Violation of consent decree, court order, or administrative order",
-            SeverityCode = "FRV",
+            SeverityCode = ViolationSeverity.FRV,
             Deprecated = false,
         },
         new()
         {
             Code = "VLSP",
             Description = "Violation of emission limit, emission standard, surrogate parameter",
-            SeverityCode = "FRV",
+            SeverityCode = ViolationSeverity.FRV,
             Deprecated = false,
         },
         new()
         {
             Code = "VWPS",
             Description = "Violation of Work Practice Standard",
-            SeverityCode = "FRV",
+            SeverityCode = ViolationSeverity.FRV,
             Deprecated = false,
         },
         new()
         {
             Code = "VNS1",
             Description = "Historic - In Violation No Schedule (1)",
-            SeverityCode = "FRV",
+            SeverityCode = ViolationSeverity.FRV,
             Deprecated = true,
         },
         new()
         {
             Code = "NMS",
             Description = "Historic - In Violation Not Meeting Schedule (6)",
-            SeverityCode = "FRV",
+            SeverityCode = ViolationSeverity.FRV,
             Deprecated = true,
         },
         new()
         {
             Code = "URG",
             Description = "Historic - In Violation Unknown with Regard to Schedule (7)",
-            SeverityCode = "FRV",
+            SeverityCode = ViolationSeverity.FRV,
             Deprecated = true,
         },
         new()
         {
             Code = "VEPC",
             Description = "Historic - In Violation with Regard to Both Emissions and Procedural Compliance (B)",
-            SeverityCode = "FRV",
+            SeverityCode = ViolationSeverity.FRV,
             Deprecated = true,
         },
         new()
         {
             Code = "RPC",
             Description = "Historic - In Violation with Regard to Procedural Compliance (W)",
-            SeverityCode = "FRV",
+            SeverityCode = ViolationSeverity.FRV,
             Deprecated = true,
         },
         new()
         {
             Code = "CRIT1",
             Description = "Criteria 1 - Failure to obtain NSR permit and/or install BACT/LAER",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = false,
         },
         new()
@@ -142,21 +142,21 @@ public static class ViolationTypeData
             Code = "CRIT2",
             Description =
                 "Criteria 2 - NSR/PSD/SIP, violation of emission limit, emission standard, or surrogate parameter",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = false,
         },
         new()
         {
             Code = "CRIT3",
             Description = "Criteria 3 - NSPS, violation of emission limit, emission standard, surrogate parameter",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = false,
         },
         new()
         {
             Code = "CRIT4",
             Description = "Criteria 4 - NESHAP, violation of emission limit, emission standard, surrogate parameter",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = false,
         },
         new()
@@ -164,133 +164,133 @@ public static class ViolationTypeData
             Code = "CRIT5",
             Description =
                 "Criteria 5 - Violation of work practice standard, testing requirements, monitoring requirements, recordkeeping or reporting requirements",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = false,
         },
         new()
         {
             Code = "CRIT6",
             Description = "Criteria 6 - Other HPV",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = false,
         },
         new()
         {
             Code = "M1A",
             Description = "Historic - Any violation of emission limit detected via stack testing",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "M3F",
             Description = "Historic - Any violation of non-opacity (>24 hours standard) via CEM",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "GC9",
             Description = "Historic - Chronic or Recalcitrant Violation",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "DIS",
             Description = "Historic - Discretionary HPV",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "GC8",
             Description = "Historic - Emission Violation",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "GC4",
             Description = "Historic - Enforcement Violation",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "GC1",
             Description = "Historic - Fail to Obtain PSD or NSR Permit",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "G10",
             Description = "Historic - Section 112(r) Violation",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "GC7",
             Description = "Historic - Testing, Monitoring, Recordkeeping, or Reporting Violation",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "GC5",
             Description = "Historic - Title V Certification Violation",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "GC6",
             Description = "Historic - Title V Permit Application Violation",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "GC2",
             Description = "Historic - Violation Of Air Toxics Requirements",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "M2A",
             Description = "Historic - Violation of Direct Surrogate for >5% of limit for >3% of OT (operating time)",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "M2B",
             Description = "Historic - Violation of Direct Surrogate for >50% of OT (operating time)",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "M2C",
             Description = "Historic - Violation of Direct Surrogate of >25% for 2 reporting periods",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "M1B",
             Description = "Historic - Violation of emission limits > 15% via sampling",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "M1C",
             Description = "Historic - Violation of emission limits > the SST (Supplemental Significant Threshold)",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
@@ -298,21 +298,21 @@ public static class ViolationTypeData
             Code = "M3B",
             Description =
                 "Historic - Violation of non- opacity standard via CEM of the SST(Supplemental Significant Threshold)",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "M3A",
             Description = "Historic - Violation of non-opacity standard via CEM of >15% for >5% of operating time",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "M3C",
             Description = "Historic - Violation of non-opacity standard via CEM of >15% for 2 reporting periods",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
@@ -320,7 +320,7 @@ public static class ViolationTypeData
             Code = "M3E",
             Description =
                 "Historic - Violation of non-opacity standard via CEM of >25% during two consecutive reporting periods",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
@@ -328,7 +328,7 @@ public static class ViolationTypeData
             Code = "M3D",
             Description =
                 "Historic - Violation of non-opacity standard via CEM of >50% of the operating time during the reporting period",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
@@ -336,7 +336,7 @@ public static class ViolationTypeData
             Code = "M4C",
             Description =
                 "Historic - Violation of opacity standards (> 20%) via Continuous Opacity Monitoring (COM) for >5% of operating Time",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
@@ -344,35 +344,35 @@ public static class ViolationTypeData
             Code = "M4D",
             Description =
                 "Historic - Violation of opacity standards (>20%) via Continuous Opacity Monitoring (COM) for 5% operating time",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "M4F",
             Description = "Historic - Violation of opacity standards (>20%) via Method 9 VE Readings",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "M4A",
             Description = "Historic - Violation of opacity standards (0-20%) via Continuous Opacity Monitoring (COM)",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "M4E",
             Description = "Historic - Violation of opacity standards (0-20%) via Method 9 VE Readings",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "GC3",
             Description = "Historic - Violation that Affects Synthetic Minor Status",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
@@ -380,21 +380,21 @@ public static class ViolationTypeData
             Code = "M4B",
             Description =
                 "Historic - Violations of opacity standards >3% of operating time via Continuous Opacity Monitoring during two consecutive reporting periods",
-            SeverityCode = "HPV",
+            SeverityCode = ViolationSeverity.HPV,
             Deprecated = true,
         },
         new()
         {
             Code = "VFEV",
             Description = "Violation of Federally-Enforceable Rule or Regulation that is not federally-reportable",
-            SeverityCode = "NFR",
+            SeverityCode = ViolationSeverity.NFR,
             Deprecated = false,
         },
         new()
         {
             Code = "VSTL",
             Description = "Violation of State, Tribal or Local Agency Only Regulation",
-            SeverityCode = "OTH",
+            SeverityCode = ViolationSeverity.OTH,
             Deprecated = false,
         },
     ];

--- a/src/EfRepository/ComplianceRepositories/CaseFileRepository.cs
+++ b/src/EfRepository/ComplianceRepositories/CaseFileRepository.cs
@@ -1,6 +1,5 @@
 ﻿using AirWeb.Domain.Compliance.EnforcementEntities.CaseFiles;
 using AirWeb.Domain.Compliance.EnforcementEntities.EnforcementActions;
-using AirWeb.Domain.Compliance.EnforcementEntities.ViolationTypes;
 using AirWeb.EfRepository.Contexts;
 using IaipDataService.Facilities;
 
@@ -20,7 +19,6 @@ public sealed class CaseFileRepository(AppDbContext context)
             .Include(caseFile => caseFile.AuditPoints
                 .OrderBy(audit => audit.When).ThenBy(audit => audit.Id))
             .Include(caseFile => caseFile.ComplianceEvents)
-            .Include(caseFile => caseFile.ViolationType)
             .Include(caseFile => caseFile.EnforcementActions)
             .ThenInclude(action => action.Reviews).ThenInclude(review => review.RequestedBy)
             .Include(caseFile => caseFile.EnforcementActions)
@@ -28,10 +26,6 @@ public sealed class CaseFileRepository(AppDbContext context)
             .Include(caseFile => caseFile.EnforcementActions)
             .ThenInclude(action => ((ConsentOrder)action).StipulatedPenalties)
             .SingleOrDefaultAsync(fce => fce.Id.Equals(id), token);
-
-    public async Task<ViolationType?> GetViolationTypeAsync(string? code, CancellationToken token = default) =>
-        await Context.ViolationTypes.AsTracking().SingleOrDefaultAsync(v => v.Code == code, token)
-            .ConfigureAwait(false);
 
     public async Task<IEnumerable<Pollutant>> GetPollutantsAsync(int id, CancellationToken token = default) =>
         (await GetAsync(id, token).ConfigureAwait(false)).GetPollutants();

--- a/src/EfRepository/Contexts/AppDbContext.cs
+++ b/src/EfRepository/Contexts/AppDbContext.cs
@@ -5,7 +5,6 @@ using AirWeb.Domain.Compliance.ComplianceEntities.Fces;
 using AirWeb.Domain.Compliance.EnforcementEntities.CaseFiles;
 using AirWeb.Domain.Compliance.EnforcementEntities.EnforcementActions;
 using AirWeb.Domain.Compliance.EnforcementEntities.EnforcementActions.ActionProperties;
-using AirWeb.Domain.Compliance.EnforcementEntities.ViolationTypes;
 using AirWeb.Domain.Core.Entities;
 using AirWeb.Domain.Sbeap.Entities.ActionItems;
 using AirWeb.Domain.Sbeap.Entities.ActionItemTypes;
@@ -33,7 +32,6 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : IdentityDbCo
 
     // -- Compliance lookup tables (stored in the `Lookups` table)
     public DbSet<NotificationType> NotificationTypes { get; set; } = null!;
-    public DbSet<ViolationType> ViolationTypes { get; set; } = null!;
 
     // FCEs
     public DbSet<Fce> Fces { get; set; } = null!;

--- a/src/EfRepository/Contexts/AppDbContextConfiguration.cs
+++ b/src/EfRepository/Contexts/AppDbContextConfiguration.cs
@@ -3,7 +3,6 @@ using AirWeb.Domain.Compliance.ComplianceEntities.Fces;
 using AirWeb.Domain.Compliance.EnforcementEntities.CaseFiles;
 using AirWeb.Domain.Compliance.EnforcementEntities.EnforcementActions;
 using AirWeb.Domain.Compliance.EnforcementEntities.EnforcementActions.ActionProperties;
-using AirWeb.Domain.Compliance.EnforcementEntities.ViolationTypes;
 using AirWeb.Domain.Core;
 using AirWeb.Domain.Core.Entities;
 using AirWeb.Domain.Sbeap.Entities.ActionItems;
@@ -31,7 +30,6 @@ internal static class AppDbContextConfiguration
 
         // -- Compliance lookups
         builder.Entity<Notification>().Navigation(notification => notification.NotificationType).AutoInclude();
-        builder.Entity<CaseFile>().Navigation(caseFile => caseFile.ViolationType).AutoInclude();
 
         // User data should be included in all entities.
 
@@ -248,7 +246,6 @@ internal static class AppDbContextConfiguration
         builder.Entity<EnforcementAction>().Property(e => e.ActionType).HasConversion<string>();
         builder.Entity<EnforcementAction>().Property(e => e.Status).HasConversion<string>();
         builder.Entity<EnforcementActionReview>().Property(e => e.Result).HasConversion<string>();
-        builder.Entity<ViolationType>().Property(e => e.SeverityCode).HasConversion<string>();
 
         // Data exchange status
         builder.Entity<CaseFile>().Property(e => e.DataExchangeStatus).HasConversion<string>();

--- a/src/EfRepository/Contexts/AppDbContextConfiguration.cs
+++ b/src/EfRepository/Contexts/AppDbContextConfiguration.cs
@@ -3,6 +3,7 @@ using AirWeb.Domain.Compliance.ComplianceEntities.Fces;
 using AirWeb.Domain.Compliance.EnforcementEntities.CaseFiles;
 using AirWeb.Domain.Compliance.EnforcementEntities.EnforcementActions;
 using AirWeb.Domain.Compliance.EnforcementEntities.EnforcementActions.ActionProperties;
+using AirWeb.Domain.Compliance.EnforcementEntities.ViolationTypes;
 using AirWeb.Domain.Core;
 using AirWeb.Domain.Core.Entities;
 using AirWeb.Domain.Sbeap.Entities.ActionItems;
@@ -247,6 +248,7 @@ internal static class AppDbContextConfiguration
         builder.Entity<EnforcementAction>().Property(e => e.ActionType).HasConversion<string>();
         builder.Entity<EnforcementAction>().Property(e => e.Status).HasConversion<string>();
         builder.Entity<EnforcementActionReview>().Property(e => e.Result).HasConversion<string>();
+        builder.Entity<ViolationType>().Property(e => e.SeverityCode).HasConversion<string>();
 
         // Data exchange status
         builder.Entity<CaseFile>().Property(e => e.DataExchangeStatus).HasConversion<string>();

--- a/src/EfRepository/Contexts/SeedDevData/DbSeedDataHelpers.cs
+++ b/src/EfRepository/Contexts/SeedDevData/DbSeedDataHelpers.cs
@@ -1,6 +1,5 @@
 ﻿using AirWeb.Domain.Compliance.ComplianceEntities.ComplianceMonitoring;
 using AirWeb.Domain.Compliance.EnforcementEntities.EnforcementActions;
-using AirWeb.Domain.Compliance.EnforcementEntities.ViolationTypes;
 using AirWeb.Domain.Sbeap.ValueObjects;
 using AirWeb.TestData.Compliance;
 using AirWeb.TestData.Enforcement;
@@ -17,7 +16,6 @@ public static class DbSeedDataHelpers
         SeedOfficeData(context);
         SeedIdentityData(context);
 
-        SeedViolationTypeData(context);
         SeedFceData(context);
         SeedNotificationTypeData(context);
         SeedComplianceWorkData(context);
@@ -44,13 +42,6 @@ public static class DbSeedDataHelpers
 
         OfficeData.ClearData();
         UserData.ClearData();
-    }
-
-    private static void SeedViolationTypeData(AppDbContext context)
-    {
-        if (context.ViolationTypes.Any()) return;
-        context.ViolationTypes.AddRange(ViolationTypeData.ViolationTypes);
-        context.SaveChanges();
     }
 
     private static void SeedCaseFileData(AppDbContext context)

--- a/src/EfRepository/Migrations/20260427193248_RemoveViolationTypeTable.Designer.cs
+++ b/src/EfRepository/Migrations/20260427193248_RemoveViolationTypeTable.Designer.cs
@@ -4,6 +4,7 @@ using AirWeb.EfRepository.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AirWeb.EfRepository.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260427193248_RemoveViolationTypeTable")]
+    partial class RemoveViolationTypeTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/EfRepository/Migrations/20260427193248_RemoveViolationTypeTable.cs
+++ b/src/EfRepository/Migrations/20260427193248_RemoveViolationTypeTable.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AirWeb.EfRepository.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveViolationTypeTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_EnforcementCaseFiles_ViolationTypes_ViolationTypeCode",
+                table: "EnforcementCaseFiles");
+
+            migrationBuilder.DropTable(
+                name: "ViolationTypes");
+
+            migrationBuilder.DropIndex(
+                name: "IX_EnforcementCaseFiles_ViolationTypeCode",
+                table: "EnforcementCaseFiles");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ViolationTypes",
+                columns: table => new
+                {
+                    Code = table.Column<string>(type: "nvarchar(5)", maxLength: 5, nullable: false),
+                    Deprecated = table.Column<bool>(type: "bit", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(300)", maxLength: 300, nullable: false),
+                    SeverityCode = table.Column<string>(type: "nvarchar(3)", maxLength: 3, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ViolationTypes", x => x.Code);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EnforcementCaseFiles_ViolationTypeCode",
+                table: "EnforcementCaseFiles",
+                column: "ViolationTypeCode");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_EnforcementCaseFiles_ViolationTypes_ViolationTypeCode",
+                table: "EnforcementCaseFiles",
+                column: "ViolationTypeCode",
+                principalTable: "ViolationTypes",
+                principalColumn: "Code");
+        }
+    }
+}

--- a/src/MemRepository/ComplianceRepositories/CaseFileMemRepository.cs
+++ b/src/MemRepository/ComplianceRepositories/CaseFileMemRepository.cs
@@ -1,5 +1,4 @@
 ﻿using AirWeb.Domain.Compliance.EnforcementEntities.CaseFiles;
-using AirWeb.Domain.Compliance.EnforcementEntities.ViolationTypes;
 using AirWeb.TestData.Enforcement;
 using IaipDataService.Facilities;
 
@@ -18,9 +17,6 @@ public sealed class CaseFileMemRepository : BaseRepositoryWithMapping<CaseFile, 
         caseFile?.Comments.RemoveAll(comment => comment.IsDeleted);
         return caseFile;
     }
-
-    public Task<ViolationType?> GetViolationTypeAsync(string? code, CancellationToken token = default) =>
-        Task.FromResult(ViolationTypeData.GetViolationType(code));
 
     // Pollutants & Air Programs
     public Task<IEnumerable<Pollutant>> GetPollutantsAsync(int id, CancellationToken token = default) =>

--- a/src/TestData/Enforcement/CaseFileData.cs
+++ b/src/TestData/Enforcement/CaseFileData.cs
@@ -43,21 +43,21 @@ internal static class CaseFileData
         {
             ActionNumber = 304,
             Notes = "Canceled LON + NOV - draft",
-            ViolationType = ViolationTypeData.GetRandomViolationType(),
+            ViolationTypeCode = ViolationTypeData.GetRandomViolationType().Code,
             DiscoveryDate = DateOnly.FromDateTime(DateTime.Today.AddYears(-1).AddDays(-9)),
         },
         new(305, DomainData.GetRandomFacility().Id, null)
         {
             ActionNumber = 305,
             Notes = "NOV - no response",
-            ViolationType = ViolationTypeData.GetRandomViolationType(),
+            ViolationTypeCode = ViolationTypeData.GetRandomViolationType().Code,
             DiscoveryDate = DateOnly.FromDateTime(DateTime.Today.AddYears(-2).AddDays(-19)),
         },
         new(306, DomainData.GetRandomFacility().Id, null)
         {
             ActionNumber = 306,
             Notes = "NOV + NFA",
-            ViolationType = ViolationTypeData.GetRandomViolationType(),
+            ViolationTypeCode = ViolationTypeData.GetRandomViolationType().Code,
             DiscoveryDate = DateOnly.FromDateTime(DateTime.Today.AddYears(-3).AddDays(-100)),
         },
         new(307, DomainData.GetRandomFacility().Id, null)
@@ -66,42 +66,42 @@ internal static class CaseFileData
             ClosedDate = DateOnly.FromDateTime(DateTime.Today.AddYears(-3).AddDays(-60)),
             ClosedBy = UserData.GetRandomUser(),
             Notes = "Combined NOV/NFA",
-            ViolationType = ViolationTypeData.GetRandomViolationType(),
+            ViolationTypeCode = ViolationTypeData.GetRandomViolationType().Code,
             DiscoveryDate = DateOnly.FromDateTime(DateTime.Today.AddYears(-3).AddDays(-100)),
         },
         new(308, DomainData.GetRandomFacility().Id, null)
         {
             ActionNumber = 308,
             Notes = "NOV + Proposed Consent Order - draft",
-            ViolationType = ViolationTypeData.GetRandomViolationType(),
+            ViolationTypeCode = ViolationTypeData.GetRandomViolationType().Code,
             DiscoveryDate = DateOnly.FromDateTime(DateTime.Today.AddYears(-2).AddDays(-41)),
         },
         new(309, DomainData.GetRandomFacility().Id, null)
         {
             ActionNumber = 309,
             Notes = "Straight to Proposed CO - no response received",
-            ViolationType = ViolationTypeData.GetRandomViolationType(),
+            ViolationTypeCode = ViolationTypeData.GetRandomViolationType().Code,
             DiscoveryDate = DateOnly.FromDateTime(DateTime.Today.AddYears(-2).AddDays(41)),
         },
         new(310, DomainData.GetRandomFacility().Id, null)
         {
             ActionNumber = 310,
             Notes = "Proposed CO + signed Consent Order received",
-            ViolationType = ViolationTypeData.GetRandomViolationType(),
+            ViolationTypeCode = ViolationTypeData.GetRandomViolationType().Code,
             DiscoveryDate = DateOnly.FromDateTime(DateTime.Today.AddYears(-2).AddDays(-12)),
         },
         new(311, DomainData.GetRandomFacility().Id, null)
         {
             ActionNumber = 311,
             Notes = "Consent Order + Stipulated Penalties - executed",
-            ViolationType = ViolationTypeData.GetRandomViolationType(),
+            ViolationTypeCode = ViolationTypeData.GetRandomViolationType().Code,
             DiscoveryDate = DateOnly.FromDateTime(DateTime.Today.AddYears(-2).AddDays(141)),
         },
         new(312, DomainData.GetRandomFacility().Id, null)
         {
             ActionNumber = 312,
             Notes = "Consent Order - closed",
-            ViolationType = ViolationTypeData.GetRandomViolationType(),
+            ViolationTypeCode = ViolationTypeData.GetRandomViolationType().Code,
             DiscoveryDate = DateOnly.FromDateTime(DateTime.Today.AddYears(-4).AddDays(-210)),
             ClosedDate = DateOnly.FromDateTime(DateTime.Today.AddYears(-3).AddMonths(1)),
         },
@@ -109,14 +109,14 @@ internal static class CaseFileData
         {
             ActionNumber = 313,
             Notes = "Administrative Order - executed",
-            ViolationType = ViolationTypeData.GetRandomViolationType(),
+            ViolationTypeCode = ViolationTypeData.GetRandomViolationType().Code,
             DiscoveryDate = DateOnly.FromDateTime(DateTime.Today.AddYears(-1).AddDays(-200)),
         },
         new(314, DomainData.GetRandomFacility().Id, null)
         {
             ActionNumber = 314,
             Notes = "Administrative Order - closed",
-            ViolationType = ViolationTypeData.GetRandomViolationType(),
+            ViolationTypeCode = ViolationTypeData.GetRandomViolationType().Code,
             DiscoveryDate = DateOnly.FromDateTime(DateTime.Today.AddYears(-2).AddDays(-320)),
             ClosedDate = DateOnly.FromDateTime(DateTime.Today.AddYears(-2).AddDays(-200)),
         },

--- a/src/WebApp/Pages/Enforcement/Details.cshtml
+++ b/src/WebApp/Pages/Enforcement/Details.cshtml
@@ -3,6 +3,7 @@
 @using AirWeb.AppServices.Compliance.Enforcement.Permissions
 @using AirWeb.Domain.Compliance.DataExchange
 @using AirWeb.Domain.Compliance.EnforcementEntities.EnforcementActions
+@using AirWeb.Domain.Compliance.EnforcementEntities.ViolationTypes
 @using AirWeb.WebApp.Pages.Shared
 @using AirWeb.WebApp.Pages.Shared.DisplayTemplates
 @using AirWeb.WebApp.Pages.Shared.EditorTemplates
@@ -165,7 +166,7 @@
                 <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => caseFile.DiscoveryDate, DisplayTemplate.ShortDateOnlyNullable)</dd>
                 @if (caseFile.HasReportableEnforcement)
                 {
-                    @if (caseFile.ViolationType is { SeverityCode: "HPV" })
+                    @if (caseFile.ViolationType is { SeverityCode: ViolationSeverity.HPV })
                     {
                         <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(_ => caseFile.DayZero)</dt>
                         <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => caseFile.DayZero, DisplayTemplate.ShortDateOnlyNullable,

--- a/src/WebApp/Pages/Enforcement/Edit.cshtml.cs
+++ b/src/WebApp/Pages/Enforcement/Edit.cshtml.cs
@@ -72,6 +72,6 @@ public class EditModel(
             ComplianceRole.ComplianceManagerRole)).ToSelectList();
         ViolationTypeSelectList = new SelectList(ViolationTypeData.GetCurrent(),
             nameof(ViolationType.Code), nameof(ViolationType.Display),
-            null, nameof(ViolationType.SeverityCode));
+            null, nameof(ViolationType.SeverityCodeDisplay));
     }
 }


### PR DESCRIPTION
Violation types are already stored in memory on app load, and the DB table is not user-editable. There is no need to constantly join to this table.