### PR TITLE
Implement temporal database tables for enforcement data

### DIFF
--- a/src/EfRepository/Contexts/AppDbContext.cs
+++ b/src/EfRepository/Contexts/AppDbContext.cs
@@ -102,7 +102,8 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : IdentityDbCo
             .ConfigureLookupTableNameMaxLength()
             .ConfigureCollectionPropertySerialization()
             .ConfigureDataExchangeIndexes()
-            .ConfigureModelManagedData();
+            .ConfigureModelManagedData()
+            .ConfigureTemporalTables();
 
         // SQLite-only configuration
         if (Database.ProviderName == SqliteProvider)

--- a/src/EfRepository/Contexts/AppDbContextConfiguration.cs
+++ b/src/EfRepository/Contexts/AppDbContextConfiguration.cs
@@ -390,4 +390,18 @@ internal static class AppDbContextConfiguration
         builder.Entity<ViolationType>(e => e.HasData(ViolationTypeData.GetAll()));
         return builder;
     }
+
+    internal static ModelBuilder ConfigureTemporalTables(this ModelBuilder builder)
+    {
+        // https://learn.microsoft.com/en-us/ef/core/providers/sql-server/temporal-tables
+        builder.Entity<CaseFile>()
+            .ToTable(nameof(AppDbContext.EnforcementCaseFiles),
+                table => table.IsTemporal(t => t.UseHistoryTable("EnforcementCaseFiles_History")));
+
+        builder.Entity<EnforcementAction>()
+            .ToTable(nameof(Domain.Compliance.EnforcementEntities.EnforcementActions),
+                table => table.IsTemporal(t => t.UseHistoryTable("EnforcementActions_History")));
+
+        return builder;
+    }
 }

--- a/src/EfRepository/Contexts/AppDbContextConfiguration.cs
+++ b/src/EfRepository/Contexts/AppDbContextConfiguration.cs
@@ -393,15 +393,20 @@ internal static class AppDbContextConfiguration
 
     internal static ModelBuilder ConfigureTemporalTables(this ModelBuilder builder)
     {
+        // Refs:
+        // https://learn.microsoft.com/en-us/sql/relational-databases/tables/temporal-tables?view=sql-server-ver16
         // https://learn.microsoft.com/en-us/ef/core/providers/sql-server/temporal-tables
-        builder.Entity<CaseFile>()
-            .ToTable(nameof(AppDbContext.EnforcementCaseFiles),
-                table => table.IsTemporal(t => t.UseHistoryTable("EnforcementCaseFiles_History")));
 
-        builder.Entity<EnforcementAction>()
-            .ToTable(nameof(Domain.Compliance.EnforcementEntities.EnforcementActions),
-                table => table.IsTemporal(t => t.UseHistoryTable("EnforcementActions_History")));
+        builder.ConfigureTemporalTable<CaseFile>(nameof(AppDbContext.EnforcementCaseFiles));
+
+        builder.ConfigureTemporalTable<EnforcementAction>(nameof(Domain.Compliance.EnforcementEntities
+            .EnforcementActions));
 
         return builder;
     }
+
+    private static void ConfigureTemporalTable<TEntity>(this ModelBuilder builder, string tableName)
+        where TEntity : class =>
+        builder.Entity<TEntity>().ToTable(tableName,
+            table => table.IsTemporal(ttb => ttb.UseHistoryTable($"{tableName}_History")));
 }

--- a/src/EfRepository/Migrations/20260617183524_EnforcementTemporalTables.Designer.cs
+++ b/src/EfRepository/Migrations/20260617183524_EnforcementTemporalTables.Designer.cs
@@ -4,6 +4,7 @@ using AirWeb.EfRepository.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AirWeb.EfRepository.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260617183524_EnforcementTemporalTables")]
+    partial class EnforcementTemporalTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/EfRepository/Migrations/20260617183524_EnforcementTemporalTables.cs
+++ b/src/EfRepository/Migrations/20260617183524_EnforcementTemporalTables.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AirWeb.EfRepository.Migrations
+{
+    /// <inheritdoc />
+    public partial class EnforcementTemporalTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterTable(
+                name: "EnforcementCaseFiles")
+                .Annotation("SqlServer:IsTemporal", true)
+                .Annotation("SqlServer:TemporalHistoryTableName", "EnforcementCaseFiles_History")
+                .Annotation("SqlServer:TemporalHistoryTableSchema", null)
+                .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+
+            migrationBuilder.AlterTable(
+                name: "EnforcementActions")
+                .Annotation("SqlServer:IsTemporal", true)
+                .Annotation("SqlServer:TemporalHistoryTableName", "EnforcementActions_History")
+                .Annotation("SqlServer:TemporalHistoryTableSchema", null)
+                .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "PeriodEnd",
+                table: "EnforcementCaseFiles",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified))
+                .Annotation("SqlServer:TemporalIsPeriodEndColumn", true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "PeriodStart",
+                table: "EnforcementCaseFiles",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified))
+                .Annotation("SqlServer:TemporalIsPeriodStartColumn", true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "PeriodEnd",
+                table: "EnforcementActions",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified))
+                .Annotation("SqlServer:TemporalIsPeriodEndColumn", true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "PeriodStart",
+                table: "EnforcementActions",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified))
+                .Annotation("SqlServer:TemporalIsPeriodStartColumn", true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PeriodEnd",
+                table: "EnforcementCaseFiles")
+                .Annotation("SqlServer:TemporalIsPeriodEndColumn", true);
+
+            migrationBuilder.DropColumn(
+                name: "PeriodStart",
+                table: "EnforcementCaseFiles")
+                .Annotation("SqlServer:TemporalIsPeriodStartColumn", true);
+
+            migrationBuilder.DropColumn(
+                name: "PeriodEnd",
+                table: "EnforcementActions")
+                .Annotation("SqlServer:TemporalIsPeriodEndColumn", true);
+
+            migrationBuilder.DropColumn(
+                name: "PeriodStart",
+                table: "EnforcementActions")
+                .Annotation("SqlServer:TemporalIsPeriodStartColumn", true);
+
+            migrationBuilder.AlterTable(
+                name: "EnforcementCaseFiles")
+                .OldAnnotation("SqlServer:IsTemporal", true)
+                .OldAnnotation("SqlServer:TemporalHistoryTableName", "EnforcementCaseFiles_History")
+                .OldAnnotation("SqlServer:TemporalHistoryTableSchema", null)
+                .OldAnnotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .OldAnnotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+
+            migrationBuilder.AlterTable(
+                name: "EnforcementActions")
+                .OldAnnotation("SqlServer:IsTemporal", true)
+                .OldAnnotation("SqlServer:TemporalHistoryTableName", "EnforcementActions_History")
+                .OldAnnotation("SqlServer:TemporalHistoryTableSchema", null)
+                .OldAnnotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .OldAnnotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+        }
+    }
+}


### PR DESCRIPTION
For future reference, here is how you disable and remove the temporal tables from the database side:

```sql
begin

    ALTER TABLE dbo.EnforcementActions
        SET (SYSTEM_VERSIONING = OFF);

    ALTER TABLE dbo.EnforcementActions
        DROP PERIOD FOR SYSTEM_TIME;

    alter table dbo.EnforcementActions
        drop column PeriodStart;

    alter table dbo.EnforcementActions
        drop column PeriodEnd;

    drop table dbo.EnforcementActions_History

--

    ALTER TABLE dbo.EnforcementCaseFiles
        SET (SYSTEM_VERSIONING = OFF);

    ALTER TABLE dbo.EnforcementCaseFiles
        DROP PERIOD FOR SYSTEM_TIME;

    alter table dbo.EnforcementCaseFiles
        drop column PeriodStart;

    alter table dbo.EnforcementCaseFiles
        drop column PeriodEnd;

    drop table dbo.EnforcementCaseFiles_History

end
```