### PR TITLE
299-display-total-penalties-in-case-file-details PR

### DIFF
--- a/src/AppServices.Compliance/Enforcement/CaseFileQuery/CaseFileViewDto.cs
+++ b/src/AppServices.Compliance/Enforcement/CaseFileQuery/CaseFileViewDto.cs
@@ -48,6 +48,12 @@ public record CaseFileViewDto : IIsClosed, IIsDeleted, IHasOwner, IDeleteComment
     [Display(Name = "Air Programs")]
     public IList<AirProgram> AirPrograms { get; } = [];
 
+    [Display(Name = "Total Ordered Penalaties")]
+    public decimal? totlaOrderedPenaltyAmount { get; set; }
+
+    [Display(Name = "Total Stipulated Penalaties")]
+    public decimal? totlaStipulatedPenaltyAmount { get; set; }
+
     public IEnumerable<string> AirProgramsAsStrings => AirPrograms.Select(program => program.Description);
 
     public IList<ComplianceWorkSearchResultDto> ComplianceEvents { get; } = [];

--- a/src/AppServices.Compliance/Enforcement/CaseFileQuery/CaseFileViewDto.cs
+++ b/src/AppServices.Compliance/Enforcement/CaseFileQuery/CaseFileViewDto.cs
@@ -49,10 +49,20 @@ public record CaseFileViewDto : IIsClosed, IIsDeleted, IHasOwner, IDeleteComment
     public IList<AirProgram> AirPrograms { get; } = [];
 
     [Display(Name = "Total Ordered Penalaties")]
-    public decimal? totlaOrderedPenaltyAmount { get; set; }
+    public decimal TotalOrderedPenaltiesAmount =>
+        EnforcementActions 
+            .OfType<CoViewDto>()
+            .Where(co => !co.IsDeleted)
+            .Sum(co => co.PenaltyAmount ?? 0m);
 
     [Display(Name = "Total Stipulated Penalaties")]
-    public decimal? totlaStipulatedPenaltyAmount { get; set; }
+    public decimal TotalStipulatedPenaltiesAmount =>
+        EnforcementActions
+            .OfType<CoViewDto>()
+            .Where(co => !co.IsDeleted)
+            .Sum(co => co.StipulatedPenalties
+                .Where(sp => !sp.IsDeleted)
+                .Sum(sp => sp.Amount));
 
     public IEnumerable<string> AirProgramsAsStrings => AirPrograms.Select(program => program.Description);
 

--- a/src/AppServices.Compliance/Enforcement/CaseFileQuery/CaseFileViewDto.cs
+++ b/src/AppServices.Compliance/Enforcement/CaseFileQuery/CaseFileViewDto.cs
@@ -48,18 +48,20 @@ public record CaseFileViewDto : IIsClosed, IIsDeleted, IHasOwner, IDeleteComment
     [Display(Name = "Air Programs")]
     public IList<AirProgram> AirPrograms { get; } = [];
 
-    [Display(Name = "Total Ordered Penalaties")]
+    [Display(Name = "Total Ordered Penalties")]
     public decimal TotalOrderedPenaltiesAmount =>
-        EnforcementActions 
+        EnforcementActions
             .OfType<CoViewDto>()
             .Where(co => !co.IsDeleted)
+            .Where(co => ((IActionViewDto)co).IsIssued)
             .Sum(co => co.PenaltyAmount ?? 0m);
 
-    [Display(Name = "Total Stipulated Penalaties")]
+    [Display(Name = "Total Stipulated Penalties")]
     public decimal TotalStipulatedPenaltiesAmount =>
         EnforcementActions
             .OfType<CoViewDto>()
             .Where(co => !co.IsDeleted)
+            .Where(co => ((IActionViewDto)co).IsIssued)
             .Sum(co => co.StipulatedPenalties
                 .Where(sp => !sp.IsDeleted)
                 .Sum(sp => sp.Amount));

--- a/src/WebApp/Pages/Enforcement/Details.cshtml
+++ b/src/WebApp/Pages/Enforcement/Details.cshtml
@@ -164,10 +164,10 @@
                 <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => caseFile.ResponsibleStaff, DisplayTemplate.NameOrPlaceholder)</dd>
                 <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(_ => caseFile.DiscoveryDate)</dt>
                 <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => caseFile.DiscoveryDate, DisplayTemplate.ShortDateOnlyNullable)</dd>
-                <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(_ => caseFile.totlaOrderedPenaltyAmount)</dt>
-                <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => caseFile.totlaOrderedPenaltyAmount, DisplayTemplate.Currency)</dd>
-                <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(_ => caseFile.totlaStipulatedPenaltyAmount)</dt>
-                <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => caseFile.totlaStipulatedPenaltyAmount, DisplayTemplate.Currency)</dd>
+                <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(_ => caseFile.TotalOrderedPenaltiesAmount)</dt>
+                <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => caseFile.TotalOrderedPenaltiesAmount, DisplayTemplate.Currency)</dd>
+                <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(_ => caseFile.TotalStipulatedPenaltiesAmount)</dt>
+                <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => caseFile.TotalStipulatedPenaltiesAmount, DisplayTemplate.Currency)</dd>
                 @if (caseFile.HasReportableEnforcement)
                 {
                     @if (caseFile.ViolationType is { Severity: ViolationSeverity.HPV })

--- a/src/WebApp/Pages/Enforcement/Details.cshtml
+++ b/src/WebApp/Pages/Enforcement/Details.cshtml
@@ -164,6 +164,10 @@
                 <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => caseFile.ResponsibleStaff, DisplayTemplate.NameOrPlaceholder)</dd>
                 <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(_ => caseFile.DiscoveryDate)</dt>
                 <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => caseFile.DiscoveryDate, DisplayTemplate.ShortDateOnlyNullable)</dd>
+                <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(_ => caseFile.totlaOrderedPenaltyAmount)</dt>
+                <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => caseFile.totlaOrderedPenaltyAmount, DisplayTemplate.Currency)</dd>
+                <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(_ => caseFile.totlaStipulatedPenaltyAmount)</dt>
+                <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => caseFile.totlaStipulatedPenaltyAmount, DisplayTemplate.Currency)</dd>
                 @if (caseFile.HasReportableEnforcement)
                 {
                     @if (caseFile.ViolationType is { Severity: ViolationSeverity.HPV })

--- a/src/WebApp/Pages/Enforcement/Details.cshtml.cs
+++ b/src/WebApp/Pages/Enforcement/Details.cshtml.cs
@@ -72,8 +72,41 @@ public class DetailsModel(
         if (!UserCan[CaseFileOperation.ViewDeleted])
             CaseFile.EnforcementActions.RemoveAll(dto => dto.IsDeleted);
 
+
+        CaseFile.totlaOrderedPenaltyAmount = GetAllOrderedPenaltiesAsync();
+        CaseFile.totlaStipulatedPenaltyAmount = GetAllStipulatedPenaltiesAsync();
+
         return InitializePage();
     }
+
+    private decimal? GetAllOrderedPenaltiesAsync()
+    {
+        var sumPenaltyAmmount = 0m;
+        var coList = CaseFile.EnforcementActions.OfType<AppServices.Compliance.Enforcement.EnforcementActionQuery.CoViewDto>().ToList();
+        coList = coList.Where(co => co.PenaltyAmount != null).ToList();
+
+        if (coList != null)
+            foreach (var co in coList)
+            {
+                sumPenaltyAmmount += co.PenaltyAmount.Value;
+            }
+            return sumPenaltyAmmount;
+    }
+
+    private decimal? GetAllStipulatedPenaltiesAsync()
+    {
+        var sumStipulatedPenaltyAmount = 0m;
+        var coList = CaseFile.EnforcementActions.OfType<AppServices.Compliance.Enforcement.EnforcementActionQuery.CoViewDto>().ToList();
+        var coArray = coList.Where(co => co.StipulatedPenalties != null).ToArray();
+
+        if (coArray != null)
+            foreach (var co in coArray)
+            {
+                sumStipulatedPenaltyAmount += co.StipulatedPenalties.Sum(sp => sp.Amount);
+            }
+            return sumStipulatedPenaltyAmount;
+    }
+
 
     public async Task<IActionResult> OnPostAddEnforcementActionAsync(CancellationToken token)
     {

--- a/src/WebApp/Pages/Enforcement/Details.cshtml.cs
+++ b/src/WebApp/Pages/Enforcement/Details.cshtml.cs
@@ -64,8 +64,6 @@ public class DetailsModel(
         if (Id == 0) return RedirectToPage("Index");
         CaseFile = await caseFileService.FindDetailedAsync(Id);
         if (CaseFile is null) return NotFound();
-        
-        
 
         await SetPermissionsAsync();
         if (CaseFile.IsDeleted && !UserCan[CaseFileOperation.ViewDeleted]) return NotFound();
@@ -74,11 +72,8 @@ public class DetailsModel(
         if (!UserCan[CaseFileOperation.ViewDeleted])
             CaseFile.EnforcementActions.RemoveAll(dto => dto.IsDeleted);
 
-
-
         return InitializePage();
     }
-
 
     public async Task<IActionResult> OnPostAddEnforcementActionAsync(CancellationToken token)
     {

--- a/src/WebApp/Pages/Enforcement/Details.cshtml.cs
+++ b/src/WebApp/Pages/Enforcement/Details.cshtml.cs
@@ -64,6 +64,8 @@ public class DetailsModel(
         if (Id == 0) return RedirectToPage("Index");
         CaseFile = await caseFileService.FindDetailedAsync(Id);
         if (CaseFile is null) return NotFound();
+        
+        
 
         await SetPermissionsAsync();
         if (CaseFile.IsDeleted && !UserCan[CaseFileOperation.ViewDeleted]) return NotFound();
@@ -73,38 +75,8 @@ public class DetailsModel(
             CaseFile.EnforcementActions.RemoveAll(dto => dto.IsDeleted);
 
 
-        CaseFile.totlaOrderedPenaltyAmount = GetAllOrderedPenaltiesAsync();
-        CaseFile.totlaStipulatedPenaltyAmount = GetAllStipulatedPenaltiesAsync();
 
         return InitializePage();
-    }
-
-    private decimal? GetAllOrderedPenaltiesAsync()
-    {
-        var sumPenaltyAmmount = 0m;
-        var coList = CaseFile.EnforcementActions.OfType<AppServices.Compliance.Enforcement.EnforcementActionQuery.CoViewDto>().ToList();
-        coList = coList.Where(co => co.PenaltyAmount != null).ToList();
-
-        if (coList != null)
-            foreach (var co in coList)
-            {
-                sumPenaltyAmmount += co.PenaltyAmount.Value;
-            }
-            return sumPenaltyAmmount;
-    }
-
-    private decimal? GetAllStipulatedPenaltiesAsync()
-    {
-        var sumStipulatedPenaltyAmount = 0m;
-        var coList = CaseFile.EnforcementActions.OfType<AppServices.Compliance.Enforcement.EnforcementActionQuery.CoViewDto>().ToList();
-        var coArray = coList.Where(co => co.StipulatedPenalties != null).ToArray();
-
-        if (coArray != null)
-            foreach (var co in coArray)
-            {
-                sumStipulatedPenaltyAmount += co.StipulatedPenalties.Sum(sp => sp.Amount);
-            }
-            return sumStipulatedPenaltyAmount;
     }
 
 


### PR DESCRIPTION
### Important Information :
_Worked on issue 299. Both now visible, .cshtml dt is currently hardcoded, but if I will get told, that it is good from the functionality, i would refactor it and pr again. Name and directory from new file would be changed too. If you run the webapp, you have to make sure, that db is turned on in launch settings, because if not, it crashes (build with db context only)._ 
**_____________**

### **Functions**:
- On site loading Deatails Model hands case ID over to calculation
- Searching for all ordered/stipulated Penalty IDs with this case ID
- getting their amount and adding it together (stipulated as reqeusted seperatly)
- Page shows the Total amount in US dollar