### PR TITLE
Fix bug preventing new notifications or permit revocations

### DIFF
--- a/src/AppServices.Compliance/Compliance/ComplianceMonitoring/Notifications/NotificationCreateDto.cs
+++ b/src/AppServices.Compliance/Compliance/ComplianceMonitoring/Notifications/NotificationCreateDto.cs
@@ -4,8 +4,6 @@ namespace AirWeb.AppServices.Compliance.Compliance.ComplianceMonitoring.Notifica
 
 public record NotificationCreateDto : NotificationCommandDto, IComplianceWorkCreateDto
 {
-    [Required]
     public string? FacilityId { get; set; }
-
     public int? CaseFileId => null;
 }

--- a/src/AppServices.Compliance/Compliance/ComplianceMonitoring/PermitRevocations/PermitRevocationCreateDto.cs
+++ b/src/AppServices.Compliance/Compliance/ComplianceMonitoring/PermitRevocations/PermitRevocationCreateDto.cs
@@ -4,8 +4,6 @@ namespace AirWeb.AppServices.Compliance.Compliance.ComplianceMonitoring.PermitRe
 
 public record PermitRevocationCreateDto : PermitRevocationCommandDto, IComplianceWorkCreateDto
 {
-    [Required]
     public string? FacilityId { get; set; }
-
     public int? CaseFileId => null;
 }

--- a/src/WebApp/Pages/Compliance/SourceTest/Details.cshtml
+++ b/src/WebApp/Pages/Compliance/SourceTest/Details.cshtml
@@ -155,7 +155,7 @@
                     <div>
                         @if (Model.UserCan[ComplianceOperation.Edit])
                         {
-                            <a asp-page="../Work/Edit/Index" asp-route-id="@Model.ComplianceReview.Id.ToString()"
+                            <a asp-page="../Work/Edit/Index" asp-route-id="@review.Id.ToString()"
                                class="btn btn-outline-primary me-1">Edit</a>
                         }
                         @if (Model.UserCan[ComplianceOperation.Close] || Model.UserCan[ComplianceOperation.Reopen])
@@ -191,7 +191,7 @@
                 <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => review.ResponsibleStaff, DisplayTemplate.NameOrPlaceholder)</dd>
                 <dt class="col-sm-4 col-lg-3">Compliance Review Status</dt>
                 <dd class="col-sm-8 col-lg-9">
-                    @if (Model.ComplianceReview.IsClosed)
+                    @if (review.IsClosed)
                     {
                         @:Closed
                         if (review.ClosedBy is not null)


### PR DESCRIPTION
Reported by Jack H via email.

The `[Required]` attribute was unintensionally left on the "Create" DTOs for these two compliance work types, but should have been removed.